### PR TITLE
Fix build on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,8 +18,8 @@ sphinx:
   fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+# formats:
+#    - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
It suddenly fails when PDFs are being built - as we do not need PDFs and the error is not really obvious, let's skip PDF building for now.