### PR TITLE
Add new page with notes on how to transfer project ownership

### DIFF
--- a/how-to/index.rst
+++ b/how-to/index.rst
@@ -47,7 +47,7 @@ There are some things that can make your journey of contributing to Launchpad mu
    debug-tests-with-visual-studio-code
 
 Operating Launchpad
-------------------------
+-------------------
 
 If you have a running instance of Launchpad, there are common tasks you might need to perform.
 
@@ -61,4 +61,5 @@ If you have a running instance of Launchpad, there are common tasks you might ne
    triage-bugs
    deploying-configuration-changes
    land-update-for-loggerhead
+   transfer-project-ownership
 

--- a/how-to/transfer-project-ownership.rst
+++ b/how-to/transfer-project-ownership.rst
@@ -1,0 +1,39 @@
+Transferring ownership of a Launchpad project
+=============================================
+
+Transferring the ownership of a project in Launchpad, takes more than simply
+changing the maintainer of a project when there is private content
+associated with it.
+
+This is particularly evident for private projects, when after updating the
+project's maintainer, the maintainer themselves might not be able to see the
+private project they maintain.
+
+This is because the permissions to see and update a project lie on its sharing
+policies, which need updating in such cases.
+
+How to transfer the ownership of a private project
+--------------------------------------------------
+
+To transfer the ownership of a project from team A to team B:
+
+1. Update the project's maintainer to team B. To do so, either:
+    
+   * access your project's page and click on the "edit" button near the
+     "maintainer" field.
+    
+   * go directly to https://launchpad.net/<project_name>/+edit-people.
+
+2. Check the project's "Sharing policies". To do so, either:
+
+   * go to your project page, and click on the "Sharing" button on the right
+     panel.
+
+   * go directly to https://launchpad.net/<project name>/+sharing.
+
+3. If any sharing policies are in place, update them so that the policies
+associated with team A are now associated with team B instead.
+
+
+You can find more details about "Sharing Policies" in your project's "Sharing
+policies" page.

--- a/how-to/transfer-project-ownership.rst
+++ b/how-to/transfer-project-ownership.rst
@@ -1,7 +1,7 @@
 Transferring ownership of a Launchpad project
 =============================================
 
-Transferring the ownership of a project in Launchpad, takes more than simply
+Transferring the ownership of a project in Launchpad takes more than simply
 changing the maintainer of a project when there is private content
 associated with it.
 
@@ -9,8 +9,8 @@ This is particularly evident for private projects, when after updating the
 project's maintainer, the maintainer themselves might not be able to see the
 private project they maintain.
 
-This is because the permissions to see and update a project lie on its sharing
-policies, which need updating in such cases.
+This is because the permissions to see and update a project are defined via
+its sharing policies, which need updating in such cases.
 
 How to transfer the ownership of a private project
 --------------------------------------------------
@@ -35,5 +35,5 @@ To transfer the ownership of a project from team A to team B:
 associated with team A are now associated with team B instead.
 
 
-You can find more details about "Sharing Policies" in your project's "Sharing
+You can find more details about "Sharing policies" in your project's "Sharing
 policies" page.


### PR DESCRIPTION
This is particularly relevant for private projects and projects with private content since it requires more than just updating the 'maintainer' field