### PR TITLE
Replace link that often fails link checks in performance.rst

### DIFF
--- a/explanation/performance.rst
+++ b/explanation/performance.rst
@@ -41,7 +41,7 @@ whether you optimize for lookups, appending elements, or similar.
 
 You also should be aware of the `runtime complexity (Big O)`_ of your code.
 
-.. _runtime complexity (Big O): https://towardsdatascience.com/understanding-time-complexity-with-python-examples-2bda6e8158a7
+.. _runtime complexity (Big O): https://en.wikipedia.org/wiki/Big_O_notation
 
 Another way to ensure high performance is to use caches. Caches are usually
 used to avoid repeated expensive calculations and database lookups.


### PR DESCRIPTION
The link to a page that explains Big O Notation  (https://towardsdatascience.com/understanding-time-complexity-with-python-examples-2bda6e8158a7) often fails link checks with a 429 error.

This commit replaces that link with a wikipedia page of the same topic.