### PR TITLE
Fix '../Trunk'

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -127,7 +127,6 @@ linkcheck_ignore = [
     'https://wiki.canonical.com/InformationInfrastructure/OSA/LPHowTo/ManualCdImageMirrorProber',  # private
     'PolicyAndProcess/DatabaseSchemaChangesProcess',  # needs update
     'Trunk/Glue',  # needs update
-    '../Trunk',  # needs update
     '/Background', 
     '/Concepts',  # needs update
     '/HowToUseCodehostingLocally',  # needs update

--- a/explanation/pre-merge-reviews.rst
+++ b/explanation/pre-merge-reviews.rst
@@ -46,7 +46,7 @@ Working with PreMergeReviews
 For pre-merge reviews to be effective, however, small modifications to
 the development workflow are required. The main modification is, of
 course, requesting peer review of your code changes before merging your
-code into `Trunk <../Trunk>`__. The sections below go into the details
+code into :doc:`Trunk <branches>`__. The sections below go into the details
 of how this is best performed. There is a crib sheet for getting a
 branch merged on the WorkingWithReviews page.
 


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

On the legacy site, I found the missing link on https://dev.launchpad.net/PreMergeReviews routed to https://dev.launchpad.net/Trunk which is `branches.rst` in this repo. 

I used the convention outlined in `doc-cheat-sheet.rst`: 
```
- :doc:`Link text <index>`
```

Running `make linkcheck` throws this error, though:
```
$HOME/.../launchpad-manual/explanation/pre-merge-reviews.rst:46: WARNING: Mismatch: both interpreted text role prefix and reference suffix.
```

I'm not sure why, but it's also throwing this error, but not throwing it on `main`: 
```
(explanation/engineering-overview-translations: line   75) broken    http://www.gnu.org/software/gettext/manual/ - HTTPConnectionPool(host='www.gnu.org', port=80): Max retries exceeded with url: /software/gettext/manual/ (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x7fc96455b940>, 'Connection to www.gnu.org timed out. (connect timeout=30)'))
make: *** [Makefile:110: linkcheck] Error 1
```