### PR TITLE
Add page about how to create a bot account

### DIFF
--- a/how-to/create-bot-account.rst
+++ b/how-to/create-bot-account.rst
@@ -1,0 +1,24 @@
+===============================
+Create bot account in Launchpad
+===============================
+
+1. Request an email alias (and mappings to real email).
+   This requires filing an RT ticket
+   (e.g: `RT#c162471 <https://portal.admin.canonical.com/C162471/>`_)
+   with details about:
+
+   - The alias email address.
+
+   - Which emails addresses the alias maps to.
+   
+   In doubt, ask the Launchpad team about it.
+
+2. Create SSO account using the email alias (every real email mapped will get
+   the Ubuntu One emails with the link to validate the email).
+
+   **Note:** in case multiple users have access to this email alias,
+   anyone with access to the email alias will be able to reset the
+   password of this account.
+
+3. While still logged in with the new SSO account, go to https://launchpad.net
+   and click login.

--- a/how-to/create-bot-account.rst
+++ b/how-to/create-bot-account.rst
@@ -1,8 +1,15 @@
-===============================
-Create bot account in Launchpad
-===============================
+=================================
+Creating bot account in Launchpad
+=================================
 
-1. Request an email alias (and mappings to real email).
+.. note::
+
+   This process does **not** involve the Launchpad team - although the
+   Launchpad team is happy to assist in the process.
+   
+   The IS team is the one that handles this setup.
+
+1. Request an email alias (and mappings to a real email address).
    This requires filing an RT ticket
    (e.g: `RT#c162471 <https://portal.admin.canonical.com/C162471/>`_)
    with details about:
@@ -10,11 +17,9 @@ Create bot account in Launchpad
    - The alias email address.
 
    - Which emails addresses the alias maps to.
-   
-   In doubt, ask the Launchpad team about it.
 
-2. Create SSO account using the email alias (every real email mapped will get
-   the Ubuntu One emails with the link to validate the email).
+2. Create an SSO account using the email alias (every real email mapped will
+   get the Ubuntu One emails with the link to validate the email).
 
    **Note:** in case multiple users have access to this email alias,
    anyone with access to the email alias will be able to reset the
@@ -22,3 +27,6 @@ Create bot account in Launchpad
 
 3. While still logged in with the new SSO account, go to https://launchpad.net
    and click login.
+
+   If you are already logged in to your SSO account, you should be logged in
+   to the new bot account automatically.

--- a/how-to/index.rst
+++ b/how-to/index.rst
@@ -63,4 +63,4 @@ If you have a running instance of Launchpad, there are common tasks you might ne
    deploying-configuration-changes
    land-update-for-loggerhead
    transfer-project-ownership
-
+   create-bot-account


### PR DESCRIPTION
Adding a very short set of notes about how to add a bot account.

I am still not 100% sure whether this should simply go into the `manage-users` page, but I thought maybe a new page made sense. Let me know what your thoughts are on that.