### PR TITLE
Fix 'Database/LivePatching'

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -131,7 +131,6 @@ linkcheck_ignore = [
     '/Concepts',  # needs update
     '/HowToUseCodehostingLocally',  # needs update
     '/Loggerhead',  # needs update
-    'Database/LivePatching',  # needs update
     'Database/TableRenamePatch',  # needs update
     'Debugging#Profiling%20page%20requests',  # needs update
     'Debugging#Special%20URLs',  # needs update

--- a/how-to/database-schema-changes-process.rst
+++ b/how-to/database-schema-changes-process.rst
@@ -87,7 +87,7 @@ they will be promoted to \`master\` as part of the go-live process.
 Hot Patches
 ~~~~~~~~~~~
 
-`Database/LivePatching <Database/LivePatching>`__ explains how
+:doc:`../explanation/live-patching` explains how
 hot-patching works and what sorts of things we can hot-patch. It's the
 authority — we may be able to hot-patch more as our tooling improves.
 


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'Database/LivePatching' link in `how-to/database-schema-changes-process.rst`.

