### PR TITLE
Fix 'FixBugs'

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -133,7 +133,6 @@ linkcheck_ignore = [
     'Database/TableRenamePatch',  # needs update
     'Debugging#Profiling%20page%20requests',  # needs update
     'Debugging#Special%20URLs',  # needs update
-    'FixBug',  # needs update
     'Getting',  # needs update
     'Help',  # needs update
     'JavaScriptIntegrationTesting',  # needs update

--- a/how-to/triage-bugs.rst
+++ b/how-to/triage-bugs.rst
@@ -138,8 +138,7 @@ Selecting bugs to work on
 If you are working on Launchpad in your own time you'll most likely want
 to fix those bugs that matter to you, regardless of what importance the
 Launchpad project gives them. That's great and we welcome all bug fixes;
-we encourage you to look at `our page about fixing bugs <FixBugs>`__
-first.
+we encourage you to look at :doc:`our page about fixing bugs <fixing-bugs>` first.
 
 Members of Canonical's Launchpad team will select bugs as seems
 appropriate to them.


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'FixBugs' link in `triage-bugs.rst`. 