### PR TITLE
Fix 'Getting'

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -133,7 +133,6 @@ linkcheck_ignore = [
     'Database/TableRenamePatch',  # needs update
     'Debugging#Profiling%20page%20requests',  # needs update
     'Debugging#Special%20URLs',  # needs update
-    'Getting',  # needs update
     'Help',  # needs update
     'JavaScriptIntegrationTesting',  # needs update
     'JavascriptUnitTesting',  # needs update

--- a/explanation/launchpad-ppa.rst
+++ b/explanation/launchpad-ppa.rst
@@ -154,4 +154,4 @@ In progress
 -  focal (next, next production LTS?)
 
 When the supported series change, remember to also update
-`Getting <Getting>`__ and `Running <Running>`__.
+:doc:`../how-to/getting` and `Running <Running>`__.


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'Getting' link in `launchpad-ppa.rst`. 