### PR TITLE
Fix 'Help' link

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -134,7 +134,6 @@ linkcheck_ignore = [
     'Debugging#Profiling%20page%20requests',  # needs update
     'Debugging#Special%20URLs',  # needs update
     'Getting',  # needs update
-    'Help',  # needs update
     'JavaScriptIntegrationTesting',  # needs update
     'JavascriptUnitTesting',  # needs update
     'JavascriptUnitTesting/MockIo',  # needs update

--- a/explanation/mail.rst
+++ b/explanation/mail.rst
@@ -22,7 +22,7 @@ There are various kinds of emails in Launchpad:
 
 We should document all these kinds of email here, but right now this
 page is really in draft state, so it's just a grab bag of various
-information. We'll continue to improve it; please `help <Help>`__ us if
+information. We'll continue to improve it; please :doc:`../help` us if
 you can.
 
 Configuring Mail


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'Help' link in `explanation/mail.rst`.