### PR TITLE
Fix 'JavaScriptIntegrationTesting' link

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -135,7 +135,6 @@ linkcheck_ignore = [
     'Debugging#Special%20URLs',  # needs update
     'Getting',  # needs update
     'Help',  # needs update
-    'JavaScriptIntegrationTesting',  # needs update
     'JavascriptUnitTesting',  # needs update
     'JavascriptUnitTesting/MockIo',  # needs update
     'PolicyAndProcess/Accessibility',  # needs update

--- a/explanation/javascript-unittesting.rst
+++ b/explanation/javascript-unittesting.rst
@@ -147,6 +147,6 @@ correctly updated as a result of a user initiated action such as a
 button click. Sometimes, in production, such a user action may result in
 an XHR call where the response data is used to update the DOM. In such
 cases, you still want to be able to test the interaction within a YUI
-test without having to resort to using an `integration
-test <JavaScriptIntegrationTesting>`__. To make this easy we have
+test without having to resort to using an :doc:`integration
+test <javascript-integration-testing>`. To make this easy we have
 `MockIo class <JavascriptUnitTesting/MockIo>`__ in Launchpad.


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'JavaScriptIntegrationTesting' link in `javascript-unittesting.rst`. 