### PR TITLE
Fix 'JavascriptUnitTesting' link

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -136,7 +136,6 @@ linkcheck_ignore = [
     'Getting',  # needs update
     'Help',  # needs update
     'JavaScriptIntegrationTesting',  # needs update
-    'JavascriptUnitTesting',  # needs update
     'JavascriptUnitTesting/MockIo',  # needs update
     'PolicyAndProcess/Accessibility',  # needs update
     'Running',  # needs update

--- a/explanation/javascript-integration-testing.rst
+++ b/explanation/javascript-integration-testing.rst
@@ -6,7 +6,7 @@ We use the GradedBrowserSupport chart to determine which browsers code should
 be regularly tested in.
 
 Every JavaScript component should be tested first and foremost using
-`unit testing <JavascriptUnitTesting>`__.
+:doc:`unit testing <javascript-unittesting>`.
 
 We have infrastructure to write tests centered on the integration
 between the JavaScript component and the app server (regular API or


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'JavascriptUnitTesting' link in `explanation/javascript-integration-testing.rst`.