### PR TITLE
Fix 'Running' link

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -135,7 +135,6 @@ linkcheck_ignore = [
     'Debugging#Special%20URLs',  # needs update
     'JavascriptUnitTesting/MockIo',  # needs update
     'PolicyAndProcess/Accessibility',  # needs update
-    'Running',  # needs update
     'Soyuz',  # needs update
     'Translations/Specs/UpstreamImportIntoUbuntu/FixingIsImported/setCurrentTranslation',  # needs update
     'UI/CssSprites',  # needs update

--- a/explanation/launchpad-ppa.rst
+++ b/explanation/launchpad-ppa.rst
@@ -154,4 +154,4 @@ In progress
 -  focal (next, next production LTS?)
 
 When the supported series change, remember to also update
-:doc:`../how-to/getting` and `Running <Running>`__.
+:doc:`../how-to/getting` and :doc:`../how-to/running`.

--- a/explanation/working-with-db-devel.rst
+++ b/explanation/working-with-db-devel.rst
@@ -11,8 +11,8 @@ changes <https://dev.launchpad.net/PolicyAndProcess/DatabaseSchemaChangesProcess
 Alternative trunk
 -----------------
 
-Check out the \`db-devel\` branch in your `existing git
-clone <Running>`__:
+Check out the \`db-devel\` branch in your :doc:`existing git
+clone <../how-to/running>`:
 
 ::
 


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'Running' link in `explanation/working-with-db-devel.rst` and `explanation/launchpad-ppa.rst`. 