### PR TITLE
Fix 'UI/CssSprites' link

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -137,7 +137,6 @@ linkcheck_ignore = [
     'PolicyAndProcess/Accessibility',  # needs update
     'Soyuz',  # needs update
     'Translations/Specs/UpstreamImportIntoUbuntu/FixingIsImported/setCurrentTranslation',  # needs update
-    'UI/CssSprites',  # needs update
     'attachment:codehosting.png',  # needs update
     'https://git.launchpad.net/launchpad-mojo-specs/tree/mojo-lp-git/services',  # private
     'https://wiki.canonical.com/InformationInfrastructure/OSA/LaunchpadProductionStatus',  # private

--- a/explanation/css.rst
+++ b/explanation/css.rst
@@ -39,7 +39,7 @@ If you are dealing with sprites you may also have to run:
 
    make sprite_image
 
-`More info on sprites <UI/CssSprites>`__
+:doc:`More info on sprites <css-sprites>`.
 
 Fonts
 -----


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78

It fixes the 'UI/CssSprites' link in `explanation/css.rst`.