### PR TITLE
Correct spelling errors (The Launchpad JavaScript Build System page)

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -212,6 +212,9 @@ mbox
 mboxMailer
 memcache
 milestoneoverlay
+minified
+minifies
+minify
 minimize
 MockIo
 mockups
@@ -220,6 +223,7 @@ mozilla
 natively
 né
 newsampledata
+NPM
 OAuth
 OEM
 oid

--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/explanation/testing/index.html|!_build/explanation/feature-flags/index.html|!_build/explanation/launchpad-ppa/index.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/navigation-menus/index.html|!_build/explanation/storm-migration-guide/index.html|!_build/explanation/mail/index.html|!_build/explanation/javascript-buildsystem/index.html|!_build/explanation/javascript-integration-testing/index.html
+  - _build/**/*.html|!_build/explanation/testing/index.html|!_build/explanation/feature-flags/index.html|!_build/explanation/launchpad-ppa/index.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/navigation-menus/index.html|!_build/explanation/storm-migration-guide/index.html|!_build/explanation/mail/index.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/explanation/javascript-buildsystem.rst
+++ b/explanation/javascript-buildsystem.rst
@@ -34,8 +34,7 @@ Adding a third-party widget
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The current story for adding a third-party widget is to put it in
-``lib/lp/contrib``. You can read the mailing list discussion ( 
-https://lists.launchpad.net/launchpad-dev/msg06474.html ) about the adoption of
+``lib/lp/contrib``. You can read the `mailing list discussion`_ about the adoption of
 this location.
 
 For CSS, follow the rules above to modify the tools. If other assets are
@@ -43,6 +42,8 @@ needed, you'll need to create a link in
 ``lib/canonical/launchpad/icing`` to the proper place in
 ``lib/lp/contrib`` so the assets can be found. See
 ``lib/canonical/launchpad/icing/yui3-gallery`` for an example.
+
+.. _`mailing list discussion`: https://lists.launchpad.net/launchpad-dev/msg06474.html
 
 New Combo loader Setup
 ----------------------
@@ -54,7 +55,7 @@ minified into a build directory ``build/js/``.
 Files are served out of the ``build/js`` directory based on the YUI
 combo loader config that is constructed in the
 ``lib/lp/app/templates/base-layout-macros.pt``. These are combined and
-served out via the convoy wsgi application through Apache.
+served out via the convoy WSGI application through Apache.
 
 Developing Javascript
 ~~~~~~~~~~~~~~~~~~~~~
@@ -85,7 +86,7 @@ include that module name in any YUI block.
    LPJS.use('modulename', function (Y)...
 
 The combo loader will serve your new module when you reload the page
-ith that content on it.
+with that content on it.
 
 Launchpad CSS
 -------------


### PR DESCRIPTION
As per the issue raised in the Open Documentation Academy (Issue https://github.com/canonical/open-documentation-academy/issues/77), the page "The Launchpad JavaScript Build System" was removed from the exclusion list and `make spelling` was run to include it in the spell checker.

Some comments with regards to the changes:

* `WSGI`: the capitalised version is acceptable as per [their documentation](https://wsgi.readthedocs.io/en/latest/what.html) and was already included in the file `.custom_wordlist.txt`
* mailing list discussion URL link: changed it to a hyperlink following the same process in other pages. Tested the redirect using `make run` and it opens up the URL correctly

Thanks