### PR TITLE
Spelling checks (Launchpad Mail page)

### DIFF
--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/navigation-menus/index.html|!_build/explanation/storm-migration-guide/index.html|!_build/explanation/mail/index.html
+  - _build/**/*.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/navigation-menus/index.html|!_build/explanation/storm-migration-guide/index.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/explanation/mail.rst
+++ b/explanation/mail.rst
@@ -6,14 +6,14 @@ Launchpad Mail
 There are various kinds of emails in Launchpad:
 
 1. Mailing lists (represented by Launchpad teams). A mailing list has an
-   address \`TEAM_NAME@lists.launchpad.net`, archives
-   (`https://lists.launchpad.net/TEAM_NAME`), and an administrative
-   interface (`https://lists.canonical.com/mailman/admin/TEAM_NAME`).
+   address ``TEAM_NAME@lists.launchpad.net``, archives
+   (``https://lists.launchpad.net/TEAM_NAME``), and an administrative
+   interface (``https://lists.canonical.com/mailman/admin/TEAM_NAME``).
    Launchpad uses `Mailman <http://list.org>`__ to process these kinds
    of mails.
 2. Emails sent from one user to another (that is, an email sent "by"
    Launchpad, but really sent by user Alice when Alice uses the
-   \`https://edge.launchpad.net/~barry/+contactuser\` form to contact
+   ``https://edge.launchpad.net/~barry/+contactuser`` form to contact
    user Barry.
 3. Emails sent by Launchpad itself, such as emails sent to subscribers
    when a bug is changed.


### PR DESCRIPTION
As per the issue raised in the Open Documentation Academy (Issue canonical/open-documentation-academy#77), the page "Launchpad Mail" was removed from the exclusion list and `make spelling` was run to include it in the spell checker.

The only change that was made, was updating how the URLs are displayed. Its incorrect formatting made the spellchecker pick up `barry` as an incorrect spelled word.

The command `make run` was executed to ensure the changes resulted in the URLs being displayed correctly:

![Selection_014](https://github.com/user-attachments/assets/712cf2c8-45a8-407a-899b-5336dbbf9b64)

Thanks