### PR TITLE
Spell check (URL traversal + Navigation Menus)

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -183,6 +183,7 @@ initialized
 integrations
 io
 ip
+IPerson
 IPv
 IPython
 irc
@@ -255,6 +256,8 @@ mockups
 mojo
 mozilla
 natively
+NavigationMenu
+NavigationMenus
 né
 newsampledata
 NPM

--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -57,6 +57,7 @@ changelog
 changeset
 changesets
 charmcraft
+CanonicalUrlData
 Cmd
 CMDLINE
 Cobol
@@ -65,6 +66,8 @@ Codehosting
 codeimport
 codeimportscheduler
 CodeReviewChecklist
+codereviewmessage
+CodeReviewMessageView
 config
 configs
 ConfiguringWebApplications
@@ -174,6 +177,10 @@ https
 https
 iframe
 iharness
+IBranchMergeProposal
+IBranchTarget
+ICanonicalUrlData
+ICodeReviewMessage
 IMailDelivery
 IMailer
 importances
@@ -203,9 +210,11 @@ LandingChanges
 langpack
 LaunchpadAuthentication
 LaunchpadDatabaseRevision
+LaunchpadFormView
 LaunchpadProductionStatus
 LaunchpadObjectFactory
 LaunchpadPpa
+LaunchpadView
 lazr
 libera
 libgit
@@ -359,6 +368,7 @@ RESTful
 rocketfuel
 rollout
 rollouts
+rootsite
 rosetta
 RPC
 rst
@@ -403,6 +413,7 @@ SSO
 StagingServer
 standardized
 stdin
+stepto
 steve
 stg
 StormMigrationGuide
@@ -471,6 +482,8 @@ untriaged
 untrusted
 upstreams
 unsuffixed
+url
+urls
 userbase
 VBScript
 vbuilder

--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/navigation-menus/index.html|!_build/explanation/storm-migration-guide/index.html
+  - _build/**/*.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/storm-migration-guide/index.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/url-traversal/index.html|!_build/explanation/storm-migration-guide/index.html
+  - _build/**/*.html|!_build/explanation/branches/index.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/storm-migration-guide/index.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/explanation/navigation-menus.rst
+++ b/explanation/navigation-menus.rst
@@ -4,9 +4,9 @@ Navigation menus
 .. include:: ../includes/important_not_revised.rst
 
 When linking different views in Launchpad page templates it is recommend
-to use the !NavigationMenu attached to each facet of that object.
+to use the NavigationMenu attached to each facet of that object.
 
-The !NavigationMenus are defined in the *browser* code.
+The NavigationMenus are defined in the *browser* code.
 
 An object can have multiple *facets*. For example IPerson has a 'code',
 'overview', 'translation' .. etc facets.
@@ -37,7 +37,7 @@ An
 
 will only return the text without the anchor tag.
 
-From withing a page template, you can use the following TAL expresion to
+From withing a page template, you can use the following TAL expression to
 generate a link:
 
 ::

--- a/explanation/url-traversal.rst
+++ b/explanation/url-traversal.rst
@@ -42,7 +42,7 @@ This specifies:
 2. attribute_to_parent defines the attribute of this interface that
    refers to the parent interface. Remember, we are starting from a
    leaf, and working back to the root URL.
-3. We are adding comments/${id } to the path of the parent Interface.
+3. We are adding comments/${id} to the path of the parent Interface.
    Where id is the id field of the instance.
 4. rootsite is the subdomain this URL should be rooted at
 
@@ -84,8 +84,8 @@ Next, you need to implement the factory:
 The function decorators helps reduce the ZCML needed for registration,
 they specify:
 
-1. The interface that the adapter will provide: \`ICanonicalUrlData`.
-2. The objects that the adapter works with: \`IBranchTarget`.
+1. The interface that the adapter will provide: ``ICanonicalUrlData``.
+2. The objects that the adapter works with: ``IBranchTarget``.
 
 Note that this is using the context of the view to get the
 ICanonicalUrlData. If it were only using the view, you'd get infinite


### PR DESCRIPTION
As per the issue raised in the Open Documentation Academy (Issue https://github.com/canonical/open-documentation-academy/issues/77), the page "URL Traversal" and "Navigation Menus" were removed from the exclusion list and `make spelling` was run to include it in the spell checker.

I accidentally did not create a branch for the "Navigation Menus" page changes which resulted in this pull request having changes for two pages.

Changes include adding words to the exclusion list, spelling corrections where American English was used as well as changes to the formatting for displaying inline code

Thanks