### PR TITLE
Spelling checks (Security policy page)

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -4,6 +4,7 @@ adapter's
 AddingLaunchpadCelebrity
 analyze
 analyzer
+AnyPerson
 api
 AppleApplications
 appmanifest
@@ -15,6 +16,7 @@ artifacts
 aspirational
 AssertionsInLaunchpad
 attrgetter
+AttributeError
 auditable
 auth
 authorization
@@ -142,6 +144,7 @@ fastnodowntime
 favicons
 FK
 flavor
+ForbiddenAttribute
 FooBar
 foofunc
 formatter
@@ -380,6 +383,7 @@ SafariWebContent
 screencast
 ScreenCasts
 sdist
+SecurityProxy
 segfaulted
 sendmail
 SendmailMailer
@@ -479,6 +483,7 @@ unauthorized
 Uncomment
 unittest
 unobvious
+unproxied
 untriaged
 untrusted
 upstreams

--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/explanation/code/index.html|!_build/explanation/security-policy/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/storm-migration-guide/index.html
+  - _build/**/*.html|!_build/explanation/code/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/storm-migration-guide/index.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/explanation/security-policy.rst
+++ b/explanation/security-policy.rst
@@ -7,7 +7,7 @@ Launchpad uses "permission" to control access to views, object
 attributes and object methods.
 
 Permission are granted based on the context object type (its interface)
-by an ``IAuthorization`` adapters. Traditionally these adapters have
+by an ``IAuthorization`` adaptors. Traditionally these adaptors have
 all been defined in the ``canonical.launchpad.security`` module, but
 they are being moved out in the ``security.py`` module of the specific
 application.
@@ -76,7 +76,7 @@ permission is assigned to a given attribute, attempting to access it is
 **forbidden**. If there is a permission assigned to it, and the current
 user does not have that permission, attempting it is **unauthorized**.
 If the current user has the correct permission, then that attribute will
-behave almost exactly the same as it would on an un-proxied object. The
+behave almost exactly the same as it would on an unproxied object. The
 main difference is that any return values may be wrapped in a
 SecurityProxy as well.
 


### PR DESCRIPTION
As per the issue raised in the Open Documentation Academy (Issue https://github.com/canonical/open-documentation-academy/issues/77), the page "Security Policy" was removed from the exclusion list and `make spelling` was run to include it in the spell checker.

All qualifying words were added to the exclusion list and words such as `adapters` and `un-proxied` were corrected in the relevant .rst file.

Thanks