### PR TITLE
Check Spelling (Database Performance page)

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -32,6 +32,8 @@ backported
 backtrace
 Backtraces
 barfunc
+BatchNavigator
+batchnavigator
 Becca
 BEM
 Bionic's
@@ -90,6 +92,7 @@ Dalia's
 Danilo
 DatabaseSchemaChangesProcess
 DatabaseSetup
+DateTimeJSONEncoder
 DatetimeUsageGuide
 DavidAllouche
 dbpatches
@@ -104,9 +107,12 @@ debhelper
 debian
 DebuggingWithGdb
 debversion
+DecoratedResultSet
+DecoratedResultSets
 defense
 defense
 deps
+Desc
 dev
 dh
 dia
@@ -147,6 +153,7 @@ flavor
 ForbiddenAttribute
 FooBar
 foofunc
+foos
 formatter
 formlib
 FreshLogs
@@ -178,6 +185,7 @@ html
 http
 https
 https
+indexable
 iframe
 iharness
 IBranchMergeProposal
@@ -197,7 +205,9 @@ IPerson
 IPv
 IPython
 irc
+IRangeFactory
 IRCMeetings
+iter
 javascript
 JavascriptUnitTesting
 Javadoc
@@ -206,6 +216,7 @@ jenkins
 jinja
 js
 JScript
+JSONEncoder
 keyring
 kiko
 kompare
@@ -222,6 +233,7 @@ lazr
 libera
 libgit
 lifecycle
+ListRangeFactory
 listdir
 LivePatching
 LiveScript
@@ -337,8 +349,13 @@ ppa
 PPA
 PQM
 pre
+pre_iter_hook
+prejoining
+prejoins
 PreMergeReviews
 prepending
+prepopulate
+prepopulation
 preprocessed
 prioritize
 prober
@@ -357,6 +374,7 @@ PyPI
 qa
 QAProcess
 qastaging
+QueryCollector
 queueddelivery
 queuedDelivery
 QueuedDelivery
@@ -369,6 +387,8 @@ realizes
 ReleaseCycles
 repo
 RESTful
+resultset
+ResultSets
 rocketfuel
 rollout
 rollouts
@@ -392,6 +412,7 @@ setUp
 setupDTCBrowser
 setupRosettaExpertBrowser
 setuptools
+simplejson
 simplestreams
 slony
 Slony
@@ -410,6 +431,8 @@ soyuz
 specialized
 specializes
 sql
+SQLBase
+SQLObjectResultSets
 SRE
 SREs
 srv
@@ -422,6 +445,8 @@ stepto
 steve
 stg
 StormMigrationGuide
+StormRangeFactory
+StormStatementRecorder
 stubmailer
 stubMailer
 StyleGuides
@@ -430,6 +455,7 @@ subclassing
 subdirectory
 subprocess
 subproject
+subselects
 sudo
 SuggestivePOTemplate
 summarized
@@ -443,6 +469,7 @@ syntaxes
 systemd
 TableRenamePatch
 talisker
+TAs
 TeamEmail
 templating
 testability
@@ -498,6 +525,7 @@ virtualenv
 virtualenvs
 VPN
 VPOTExport
+webapp
 webdav
 webhook
 webservice

--- a/.sphinx/spellingcheck.yaml
+++ b/.sphinx/spellingcheck.yaml
@@ -9,7 +9,7 @@ matrix:
     - .custom_wordlist.txt
     output: .sphinx/.wordlist.dic
   sources:
-  - _build/**/*.html|!_build/explanation/code/index.html|!_build/explanation/database-performance/index.html|!_build/explanation/storm-migration-guide/index.html
+  - _build/**/*.html|!_build/explanation/code/index.html|!_build/explanation/storm-migration-guide/index.html
   pipeline:
   - pyspelling.filters.html:
       comments: false

--- a/explanation/database-performance.rst
+++ b/explanation/database-performance.rst
@@ -88,7 +88,7 @@ can be used to do this in combination with a
 
 Be sure to clear these caches with a Storm invalidation hook, to avoid
 test suite fallout. Objects are not reused between requests on the
-appservers, so we're generally safe there. (Our storm and sqlbase
+appservers, so we're generally safe there. (Our storm and SQLBase
 classes within the Launchpad tree have these hooks, so you only need to
 manually invalidate if you are using storm directly).
 
@@ -137,7 +137,7 @@ one of these tools.
     
 
 -  StormStatementRecorder, LP_DEBUG_SQL=1, LP_DEBUG_SQL_EXTRA=1,
-   QueryCollector. In extremis you can also turn on statement logging in
+   QueryCollector. In extremes you can also turn on statement logging in
    postgresql. [Note: please add more detail if you are reading this and
    have the time and knowledge.]
 -  Raise an exception at a convenient point, to cause a real OOPS.
@@ -146,7 +146,7 @@ Efficient batching of SQL result sets: StormRangeFactory
 --------------------------------------------------------
 
 Batched result sets are rendered via the class
-canonical.launchpad.webapp.bachting.BatchNavigator. (This class is a
+canonical.launchpad.webapp.batching.BatchNavigator. (This class is a
 thin wrapper around lazr.batchnavigator.BatchNavigator.)
 
 BatchNavigator delegates the retrieval of batches from a result set to


### PR DESCRIPTION
As per the issue raised in the Open Documentation Academy (Issue canonical/open-documentation-academy#77), the page "Database Performance" was removed from the exclusion list and `make spelling` was run to include it in the spell checker.

All qualifying words were added to the exclusion list and words such as `extermis` was corrected in the relevant .rst file.

Thanks