### PR TITLE
Fix the link checker

### DIFF
--- a/reference/services/fetch-service.rst
+++ b/reference/services/fetch-service.rst
@@ -102,7 +102,7 @@ We deploy the fetch service using the specs defined in
 In order to be able to evaluate new fetch service versions, we use different
 Snap channels for qastaging and production, so we are able to
 test new releases. This information is both defined in above mentioned mojo
-specs, and in `ST118 fetch service release process <https://docs.google.com/document/d/1HZvFo78LqFGgdpM7v3teG9gV-pMyvXpXTD1vcLLv_d0/edit#heading=h.cb4jg0rqpi6q>`_.
+specs, and in `ST118 fetch service release process <https://docs.google.com/document/d/1HZvFo78LqFGgdpM7v3teG9gV-pMyvXpXTD1vcLLv_d0/>`_.
 
 Qastaging
 ~~~~~~~~~


### PR DESCRIPTION
The build fails due to a reference to a Google doc in edit mode (even though it didn't in my earlier PR.)