### PR TITLE
add 'Soyuz' link

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -134,7 +134,6 @@ linkcheck_ignore = [
     'Debugging#Special%20URLs',  # needs update
     'JavascriptUnitTesting/MockIo',  # needs update
     'PolicyAndProcess/Accessibility',  # needs update
-    'Soyuz',  # needs update
     'Translations/Specs/UpstreamImportIntoUbuntu/FixingIsImported/setCurrentTranslation',  # needs update
     'attachment:codehosting.png',  # needs update
     'https://git.launchpad.net/launchpad-mojo-specs/tree/mojo-lp-git/services',  # private

--- a/explanation/code.rst
+++ b/explanation/code.rst
@@ -23,7 +23,7 @@ system. The major sub-systems are:
 -  Branch source code browser (`cgit <https://git.zx2c4.com/cgit/>`__
    for Git; :doc:`loggerhead <../how-to/land-update-for-loggerhead>` for Bazaar)
 -  Source package recipes (`git-build-recipe`/`bzr-builder\` integration
-   with `Soyuz <Soyuz>`__)
+   with :doc:`Soyuz ../how-to/use-soyuz-locally`)
 
 Each of these subsystems also have multiple moving parts and some have
 other asynchronous jobs associated with them.


### PR DESCRIPTION
This PR refers to https://github.com/canonical/open-documentation-academy/issues/78#event-13157268254

It fixes the broken 'Soyuz' link in `code.rst`. 