### PR TITLE
Group howto pages into dev tips

### DIFF
--- a/how-to/index.rst
+++ b/how-to/index.rst
@@ -30,7 +30,6 @@ There are some things that can make your journey of contributing to Launchpad mu
    :maxdepth: 2
 
    launchpad-development-tips
-   codehosting-locally
 
 Operating Launchpad
 -------------------
@@ -41,5 +40,3 @@ If you have a running instance of Launchpad, there are common tasks you might ne
    :maxdepth: 2
 
    operating-launchpad
-   rename-database-table
-

--- a/how-to/launchpad-development-tips.rst
+++ b/how-to/launchpad-development-tips.rst
@@ -15,3 +15,5 @@ Launchpad development tips
    debug-tests-with-visual-studio-code
    debug-buildfarm-builder
    launchpad-api-docs
+   codehosting-locally.rst
+   rename-database-table

--- a/how-to/launchpad-development-tips.rst
+++ b/how-to/launchpad-development-tips.rst
@@ -15,5 +15,5 @@ Launchpad development tips
    debug-tests-with-visual-studio-code
    debug-buildfarm-builder
    launchpad-api-docs
-   codehosting-locally.rst
+   codehosting-locally
    rename-database-table


### PR DESCRIPTION
Group `codehosting-locally` and `rename-database-table` into `how-to/launchpad-development-tips` section.