### PR TITLE
A small fix to the broken links

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -308,6 +308,7 @@ LPHowTo
 lpnet
 lpreview
 lpsetup
+lptools
 LTS
 lxc
 lxd
@@ -462,6 +463,7 @@ quickref
 quickstart
 rc
 rctp
+readthedocs
 realfavicongenerator
 realizes
 ReleaseCycles

--- a/explanation/security.rst
+++ b/explanation/security.rst
@@ -55,7 +55,7 @@ Code
 We do not use direct SQL statements, but rather use the
 `Storm ORM`_. This prevents SQL injection issues.
 
-.. _Storm ORM: https://storm.canonical.com/
+.. _Storm ORM: https://storm-orm.readthedocs.io/en/latest/index.html
 
 We are using Zope's mighty and fine-grained security framework which provides
 a generic mechanism to implement security policies on Python objects.

--- a/explanation/storm-migration-guide.rst
+++ b/explanation/storm-migration-guide.rst
@@ -6,7 +6,7 @@ Storm Migration Guide
 This guide explains how certain SQLObject concepts map to equivalent
 Storm concepts. It expects a level of familiarity in how SQLObject works
 (or at least how it is used in Launchpad). It is not a full tutorial on
-how to use Storm either - see https://storm.canonical.com/Tutorial for
+how to use Storm either - see https://storm-orm.readthedocs.io/en/latest/tutorial.html for
 that.
 
 Differences

--- a/reference/python.rst
+++ b/reference/python.rst
@@ -267,7 +267,7 @@ Database-related
 ORM
 ---
 
-We are using the `Storm <https://storm.canonical.com>`_ ORM.
+We are using the `Storm <https://storm-orm.readthedocs.io/en/latest/index.html>`_ ORM.
 
 Field attributes
 ----------------

--- a/tutorials/creating-a-rock-build-using-apis.rst
+++ b/tutorials/creating-a-rock-build-using-apis.rst
@@ -14,7 +14,7 @@ Pre-requisites
 3. You have a test project in Launchpad. You can create one `here <https://launchpad.net/projects/+new>`_.
 4. You have a repository containing a Rock recipe. You can fork the `helloworld-rock <https://launchpad.net/~launchpad/launchpad-tutorials/+git/helloworld-rock>`_ repository.
 
-If you want to create a new repository from scratch, you can start from `there <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/get-started.html>`_.
+If you want to create a new repository from scratch, you can start from `there <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/get-started/>`_.
 
 Creating the recipe
 ===================


### PR DESCRIPTION
4 links were broken because of outside factors. One of them because the rockcraft team changed the name of a page slightly. And the rest of them because the old web-page for Storm ORM was discontinued. Fixed them with their new versions.

And 2 additions to the custom word list for the spell-checking