### PR TITLE
Fix a typo in the shebang of the LXD profile shell script

### DIFF
--- a/developer/how-to/running.rst
+++ b/developer/how-to/running.rst
@@ -72,7 +72,7 @@ getting it installed and configured on your network.
 
 .. code-block:: sh
 
-    #! /bin/sh
+    #!/bin/sh
     
     id=400000  # some large uid outside of typical range, and outside of already mapped ranges in /etc/sub{u,g}id
     uid=$(id -u)


### PR DESCRIPTION
This PR removes a stray space in the shebang line of the LXD profile script.