### PR TITLE
ci: Temporarily disabling linkcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ linkcheck: install
 
 .PHONY: linkcheck
 
+linkcheck-manual: install
+	. $(VENV) ; $(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" \
+	$(SPHINXOPTS)
+
+.PHONY: linkcheck-manual
+
 
 woke: woke-install
 	woke *.rst **/*.rst \


### PR DESCRIPTION
Temporarily disabling linkcheck in CI workflow. Docs are a work in progress and linkcheck takes more than 5 hours and inevitably fails.