### PR TITLE
Mention the bzr codebrowse service decommissioning in the release notes

### DIFF
--- a/release-notes.rst
+++ b/release-notes.rst
@@ -7,7 +7,7 @@ June 2025
 
 - The `bzr` codebrowse interface (`loggerhead`) has been disabled and all codebrowse
   URLs will receive a '404 Not Found' response status code. Accessing `bzr`
-  repositories using the `bzr` CLI tool via HTTP and SSH should continue to work.
+  repositories using the `bzr` CLI tool via HTTP and SSH continues to work.
 
 17 June
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -3,6 +3,12 @@ Release Notes
 
 June 2025
 +++++++++
+27 June
+
+- The `bzr` codebrowse interface (`loggerhead`) has been disabled and all codebrowse
+  URLs will receive a '404 Not Found' response status code. Accessing `bzr`
+  repositories using the `bzr` CLI tool via HTTP and SSH should continue to work.
+
 17 June
 
 - Removed bzr codebrowse links on all pages that had them. This is in


### PR DESCRIPTION
This PR mentions the fact that we have now decommissioned the bzr codebrowse service (loggerhead) on launchpad.net