### PR TITLE
Mention deletion of mailing list creation button in release notes

### DIFF
--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+July 2025
++++++++++
+11 July
+
+- Launchpad no longer supports the creation of new mailing lists. For more
+  information, please refer to this `announcement
+  <https://blog.launchpad.net/general/sunsetting-launchpads-mailing-lists>`_.
+
 June 2025
 +++++++++
 27 June


### PR DESCRIPTION
Update the release notes to mention that, since Launchpad will soon sunset 
mailing lists, the creation of new mailing lists is no longer allowed. Users are 
redirected to the Launchpad Blog for more information.
