### PR TITLE
Fix broken internal links in User/Explanation pages

### DIFF
--- a/user/explanation/launchpad-api/index.rst
+++ b/user/explanation/launchpad-api/index.rst
@@ -1,3 +1,5 @@
+.. _launchpad-api:
+
 Launchpad API
 =============
 

--- a/user/explanation/message-rationale-headers.rst
+++ b/user/explanation/message-rationale-headers.rst
@@ -136,7 +136,7 @@ Build Mail
 
 Notifications regarding the various types of builds that Launchpad can
 perform for you have associated rationales. If you requested a source
-package recipe, `live filesystem <LiveFilesystem>`__, or snap package
+package recipe, :ref:`live filesystem <live-file-systems>`, or snap package
 build:
 
 ::

--- a/user/explanation/working-with-code/git-hosting.rst
+++ b/user/explanation/working-with-code/git-hosting.rst
@@ -262,7 +262,7 @@ will not be able to show it to you again.
 Via API
 ^^^^^^^
 
-Alternatively, you can generate access tokens using the `Launchpad
+Alternatively, you can generate access tokens using the :ref:`Launchpad
 API <launchpad-api>`, as follows:
 
 ::

--- a/user/explanation/working-with-code/git-hosting.rst
+++ b/user/explanation/working-with-code/git-hosting.rst
@@ -76,7 +76,7 @@ clone git+ssh://git.launchpad.net/REPOSITORY``.
 The rest of this documentation assumes that you have configured Git this
 way.
 
-You should check the `fingerprint <SSHFingerprints>`__ of
+You should check the :ref:`fingerprint <ssh-fingerprints>` of
 git.launchpad.net when prompted to do so by SSH.
 
 Getting code
@@ -263,7 +263,7 @@ Via API
 ^^^^^^^
 
 Alternatively, you can generate access tokens using the `Launchpad
-API <API>`__, as follows:
+API <launchpad-api>`, as follows:
 
 ::
 


### PR DESCRIPTION
This PR takes care of [Issue 237 from Open Code Academy](https://github.com/canonical/open-documentation-academy/issues/237).

It fixes the internal links using target IDs and `:ref:`, as was suggested in the related issue.
The fixed pages are: 
- user/explanation/message-rationale-headers
- user/explanation/working-with-code/git-hosting