### PR TITLE
FIX: Add Ubuntu link #265 in canonical/open-documentatiom-academy

### DIFF
--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -8,7 +8,7 @@ Launchpad manual for developers
 **Launchpad provides everything necessary to build and publish software,
 including code hosting, issue tracking, translations,
 and request tracking for bugs and features.**
-The most famous software hosted on Launchpad is Ubuntu.
+The most famous software hosted on Launchpad is `Ubuntu <https://ubuntu.com/>`_.
 
 **Launchpad provides unique features needed in modern software development,
 especially in open-source development.**


### PR DESCRIPTION
Added an anchor with a link to https://ubuntu.com/.