### PR TITLE
Added link to the word Ubuntu on the Homepage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ In this documentation
 Project and community
 ---------------------
 
-Launchpad is a member of the `Ubuntu <https://ubuntu.com/>`_. family.
+Launchpad is a member of the Ubuntu family.
 It's an open source project that warmly welcomes community projects,
 contributions, suggestions, fixes and constructive feedback.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Launchpad manual
 **Launchpad provides everything necessary to build and publish software,
 including code hosting, issue tracking, translations,
 and request tracking for bugs and features.**
-The most famous software hosted on Launchpad is Ubuntu.
+The most famous software hosted on Launchpad is `Ubuntu <https://ubuntu.com/>`_.
 
 **Launchpad provides unique features needed in modern software development,
 especially in open-source development.**
@@ -53,7 +53,7 @@ In this documentation
 Project and community
 ---------------------
 
-Launchpad is a member of the Ubuntu family.
+Launchpad is a member of the `Ubuntu <https://ubuntu.com/>`_. family.
 It's an open source project that warmly welcomes community projects,
 contributions, suggestions, fixes and constructive feedback.
 


### PR DESCRIPTION
Worked on the launchpad manual and add an anchor link to the word Ubuntu, so when users click on it , it will take them to to Ubuntu landing page.