### PR TITLE
hyperlinked the zcml directive phrase

### DIFF
--- a/docs/developer/tutorials/creating-a-page-in-launchpad.rst
+++ b/docs/developer/tutorials/creating-a-page-in-launchpad.rst
@@ -15,7 +15,7 @@ Introduction
 
 A page in Launchpad requires a view class, an interface it is related to,
 and a page template to render the HTML. These are then mapped to a page
-at a specific URL using a ZCML directive. Let us learn how to do this in
+at a specific URL using a `ZCML directive <https://zopecomponent.readthedocs.io/en/latest/zcml.html>`_. Let us learn how to do this in
 the following sections.
 
 Identifying the interface


### PR DESCRIPTION
This PR hyperlinked the 'ZCML directive' as requested in this issue: https://github.com/canonical/open-documentation-academy/issues/268