### PR TITLE
Mention fetch service option in release notes and documentation

### DIFF
--- a/docs/developer/reference/services/fetch-service.rst
+++ b/docs/developer/reference/services/fetch-service.rst
@@ -56,11 +56,9 @@ Using the fetch service
 Currently, the fetch service can only be used for building snaps, charms, rocks 
 and source packages.
 
-For `Snaps`, this option is now available in `Edit recipe`. For other types, a
-Launchpad admin is required to set the ``use_fetch_service`` flag for the
-recipe to ``true``, either in the API or in the UI by accessing the admin 
-area. The UI option may not be available for all build types the fetch service
-supports.
+For `Snaps` and `Charms`, this option is now available in the `Edit recipe` UI.
+For all recipe types, the ``use_fetch_service`` flag can be set to ``true`` in
+the API.
 
 The fetch service can be run in two modes, "strict" and "permissive", where it
 defaults to the former. The "strict" mode only allows certain resources and

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,17 +1,29 @@
 Release Notes
 =============
+September 2025
+++++++++++++++
+1 September
+
+- The 'Use Fetch Service' and 'Fetch Service Policy' options are
+  available for charms via the API and the Edit recipe page.
+
 August 2025
 +++++++++++
+21 August
+
+- The 'Use Fetch Service' and 'Fetch Service Policy' options are
+  available for rocks and source packages via the APIs.
+
 5 August
 
 - The 'Use Fetch Service' button for snaps has been moved from
-  Administer recipe to Edit recipe 
+  Administer recipe to Edit recipe.
 
 July 2025
 +++++++++
 30 July
 
-- Update appserver log rotation from daily to hourly
+- Update appserver log rotation from daily to hourly.
 
 11 July
 


### PR DESCRIPTION
Mention fetch service options in the release notes and documentation for charms, rocks, and source packages.