### PR TITLE
chore: Deleting broken link to Pbwiki.

### DIFF
--- a/docs/user/how-to/using-openid.rst
+++ b/docs/user/how-to/using-openid.rst
@@ -30,7 +30,6 @@ Where can I use it?
 You can use Launchpad to log into any of the growing number of sites that support OpenID. These include:
 
 * Blogs powered by `Blogger <http://blogger.com>`_
-* `PBWiki <http://pbwiki.com>`_ - the free wiki hosting service
 * `Wordpress <http://wordpress.org>`_ blogs using an OpenID plugin
 * `LiveJournal <http://livejournal.com>`_.
 * `SourceForge <https://sourceforge.net/>`_


### PR DESCRIPTION
The broken link to Pbwiki has recently been failing linkchecks. Additionally, the reference may be outdated since Pbwiki was renamed to Pbworks and has a different operating model. The link itself is not critical to the documentation because it was included as one of several examples of sites that support OpenID.