### PR TITLE
Update link to the Launchpad production status

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -340,7 +340,6 @@ LaunchpadFormView
 launchpadlib
 LaunchpadObjectFactory
 LaunchpadPpa
-LaunchpadProductionStatus
 LaunchpadStatementTracer
 LaunchpadView
 lazr

--- a/docs/developer/explanation/feature-flags.rst
+++ b/docs/developer/explanation/feature-flags.rst
@@ -7,8 +7,8 @@ Feature Flags
 running, and for particular features or behaviours to be exposed to only
 a subset of users or requests.**
 
-Please note, that any changes to feature flags need to be recorded on
-https://wiki.canonical.com/InformationInfrastructure/OSA/LaunchpadProductionStatus
+Please note, that any changes to feature flags need to be 
+`recorded <https://docs.google.com/document/d/1lxQJJWL2VD3mgCLp-KqDRxPYrhHv-020hn9qd2wL07Q/edit?tab=t.0>`__.
 
 Key points
 ----------
@@ -71,8 +71,8 @@ Operations
 ----------
 
 A change to a flag in production counts as a production change: it is
-made by the Launchpad team on request. Make the change `on the appropriate wiki
-page <https://wiki.canonical.com/InformationInfrastructure/OSA/LaunchpadProductionStatus>`__
+made by the Launchpad team on request. Make the change `on the appropriate
+documentation page <https://docs.google.com/document/d/1lxQJJWL2VD3mgCLp-KqDRxPYrhHv-020hn9qd2wL07Q/edit?tab=t.0>`__
 (sorry, company internal), including `an approval per the usual
 policy <https://wiki.canonical.com/Launchpad/PolicyandProcess/ProductionChangeApprovalPolicy>`__,
 and then ask in

--- a/docs/developer/how-to/debugging.rst
+++ b/docs/developer/how-to/debugging.rst
@@ -56,8 +56,7 @@ Debugging memory leaks
 
 The app servers and the Librarian install a signal handler to dump their
 memory using `meliae <https://launchpad.net/meliae>`__. To make use of
-that you just have to send the 44 signal to the `appropriate
-process <https://wiki.canonical.com/InformationInfrastructure/OSA/LaunchpadProductionStatus#Service%20Debugging>`__.
+that you just have to send the 44 signal to the appropriate process.
 This will create a file named /tmp/launchpad-memory.dump (or
 /tmp/librarian-memory.dump, for the Librarian), which you can debug
 later.


### PR DESCRIPTION
The link to the "debugging section" was broken before, so just the link was removed, but not updated.