### PR TITLE
Update bug statuses in Launchpad page

### DIFF
--- a/docs/user/reference/bug-tracker-api/bug-statuses.rst
+++ b/docs/user/reference/bug-tracker-api/bug-statuses.rst
@@ -34,7 +34,7 @@ Available to everyone
    project's codebase.
 -  ``Does Not Exist``: custom status used by the security team for
    specifying the impact of a CVE/vulnerability on a package.
--  ``Fix Released:`` a new version of the software, featuring the bug
+-  ``Fix Released``: a new version of the software, featuring the bug
    fix, has been released.
 -  *Under consideration for removal:* ``Opinion``: there is a difference
    of opinion about the bug and everyone is free to continue the


### PR DESCRIPTION
Bug statuses in Launchpad page have been changed from bold format to inline code format. 