### PR TITLE
Use correct wording for sourcecraft packages

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -613,6 +613,7 @@ Snapcraft
 snapshotting
 SolutionsLog
 sourcecode
+sourcecraft
 sourceforge
 sourcepackage
 SourcePackage

--- a/docs/developer/reference/services/fetch-service.rst
+++ b/docs/developer/reference/services/fetch-service.rst
@@ -54,7 +54,7 @@ The life-cycle of a fetch-service session within Launchpad goes as follows:
 Using the fetch service
 ~~~~~~~~~~~~~~~~~~~~~~~
 Currently, the fetch service can only be used for building snaps, charms, rocks 
-and source packages.
+and sourcecraft packages.
 
 For `Snaps` and `Charms`, this option is now available in the `Edit recipe` UI.
 For all recipe types, the ``use_fetch_service`` flag can be set to ``true`` in

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -12,7 +12,7 @@ August 2025
 21 August
 
 - The 'Use Fetch Service' and 'Fetch Service Policy' options are
-  available for rocks and source packages via the APIs.
+  available for rocks and sourcecraft packages via the APIs.
 
 5 August
 


### PR DESCRIPTION
Source packages refer to system packages, and not to the craft packages, so we need to use "sourcecraft packages" when talking about the latter.

This has been fixed.