### PR TITLE
Update the fetch service information on build-farm page

### DIFF
--- a/docs/developer/reference/services/build-farm.rst
+++ b/docs/developer/reference/services/build-farm.rst
@@ -34,7 +34,8 @@ Builders do not have direct access to the Internet, but rather need to
 acquire an authentication token to be able to access a restricted set of
 URLs on the Internet via a proxy. This can either be a squid proxy or the
 :doc:`fetch service <fetch-service>`, determined by a ``use_fetch_service``
-flag. Currently, only snaps can use the fetch service.
+flag. Currently, the fetch service can only be used for building snaps, charms,
+rocks and sourcecraft packages.
 
 Builder regions are physically co-located and consist of machines of the
 same architecture family.


### PR DESCRIPTION
Mention that the fetch service can be used for charms, rocks, and sourcecraft packages, not just snaps.