### PR TITLE
edit: Editing the information in the header and a few formatting mistakes in the homepage

### DIFF
--- a/docs/_templates/header.html
+++ b/docs/_templates/header.html
@@ -1,5 +1,8 @@
 <header id="header" class="p-navigation">
 
+
+</script>
+
   <!-- Google Tag Manager -->
   <script>
     (function(w, d, s, l, i) {
@@ -18,44 +21,52 @@
     })(window, document, 'script', 'dataLayer', 'GTM-KNX3CJC');
   </script>
 
-  <div class="p-navigation__nav" role="menubar">
+ <div class="p-navigation__nav" role="menubar">
 
     <ul class="p-navigation__links" role="menu">
 
       <li>
-        <a class="p-logo" href="https://canonical-launchpad-manual.readthedocs-hosted.com/" aria-current="page">
+        <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
           <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
-          <div class="p-logo-text p-heading--4">{{ project }}
+          <div class="p-logo-text p-heading--4">{{ "Launchpad" }}
           </div>
         </a>
-      </li>
-
-      <li class="nav-ubuntu-com">
-        <a href="https://{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
       </li>
 
       <li class="nav-ubuntu-com">
         <a href="https://bugs.launchpad.net/launchpad" class="p-navigation__link">Submit a Bug</a>
       </li>
 
-      <li class="nav-ubuntu-com">
-        <a href="/help/index.html" class="p-navigation__link">Help</a>
-      </li>
-
-      <!-- <li>
+      <li>
         <a href="#" class="p-navigation__link nav-more-links">More resources</a>
         <ul class="more-links-dropdown">
 
+          {% if discourse %}
           <li>
-            <a href="{{ discourse }}" class="p-navigation__sub-link p-dropdown__link">Forum</a>
+            <a href="{{ discourse }}" class="p-navigation__sub-link p-dropdown__link">Discourse</a>
           </li>
+          {% endif %}
 
+          {% if mattermost %}
+          <li>
+            <a href="{{ mattermost }}" class="p-navigation__sub-link p-dropdown__link">Mattermost</a>
+          </li>
+          {% endif %}
+
+          {% if matrix %}
+          <li>
+            <a href="{{ matrix }}" class="p-navigation__sub-link p-dropdown__link">Matrix</a>
+          </li>
+          {% endif %}
+
+          {% if github_url %}
           <li>
             <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">GitHub</a>
           </li>
+          {% endif %}
 
         </ul>
-      </li> -->
+      </li>
 
     </ul>
   </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ import yaml
 #
 # TODO: Update with the official name of your project or product
 
-project = "Launchpad Manual"
+project = "Launchpad"
 author = "Canonical Ltd."
 
 
@@ -34,7 +34,7 @@ author = "Canonical Ltd."
 #
 # TODO: To disable the title, set to an empty string.
 
-html_title = "project" + " documentation"
+html_title = "Launchpad manual"
 
 
 # Copyright string; shown at the bottom of the page
@@ -159,9 +159,9 @@ html_context = {
 # - https://launchpad.net/example
 # - https://git.launchpad.net/example
 #
-html_theme_options = {
-    "sidebar_hide_name": True,
-}
+# html_theme_options = {
+#     "sidebar_hide_name": True,
+# }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ In this manual
 
 The Launchpad manual is divided into two sections, according to the user:
 
-:ref:`End User documentation <launchpad-manual-for-users>` - For individuals and teams collaborating on open-source software
+:ref:`End user documentation <launchpad-manual-for-users>` - For individuals and teams collaborating on open-source software
 
 :ref:`Developer documentation <launchpad-manual-for-developers>` - For contributors to the Launchpad project itself
 
@@ -40,10 +40,9 @@ It's an open source project that warmly welcomes community projects,
 contributions, suggestions, fixes and constructive feedback.
 
 * `Code of conduct <https://ubuntu.com/community/ethos/code-of-conduct>`_
-* :doc:`Get support <help>`
+* :doc:`Getting help <help>`
 * :ref:`Feature highlights <launchpad-feature-highlights>` 
 * :doc:`Contribute to our code <developer/how-to/contributing-changes>`
-* :doc:`Contribute to our docs <contribute-to-our-docs>`
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
These are simple quality of life improvements to fix the following issues:
- The project title shows up as "Project documentation" due to incorrect declaration of a variable
- The "additional resources" drop-down menu doesn't show up in the header due to incorrect formatting of the header.html file
- Incorrect use of title case in the index page
- Redundant link to "contribute to our docs" on the homepage.