### PR TITLE
Homepage minor changes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,7 +43,6 @@ contributions, suggestions, fixes and constructive feedback.
 * :doc:`Get support <help>`
 * :ref:`Feature highlights <launchpad-feature-highlights>` 
 * :doc:`Contribute to our code <developer/how-to/contributing-changes>`
-* :doc:`Contribute to our docs <contribute-to-our-docs>`
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
Fixing incorrect use of title case and removing redundant link from the home page.
'Contribute to our docs' is already an option on the sidebar