### PR TITLE
Add 'enabling core26 support' to the release notes

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -1,5 +1,13 @@
 Release Notes
 =============
+
+October 2025
+++++++++++++
+17 October 2025
+
+- Support for the ``core26`` snap base has been enabled and recipes
+  can use it.
+
 September 2025
 ++++++++++++++
 1 September


### PR DESCRIPTION
This was done as a part of the series opening process for Ubuntu 26.04.