### PR TITLE
Add archive webhooks to documentation

### DIFF
--- a/docs/user/how-to/launchpad-api/webhooks.rst
+++ b/docs/user/how-to/launchpad-api/webhooks.rst
@@ -522,9 +522,9 @@ Triggered when the status of a source package upload changes. The payload is:
 +-------------------------+----------+---------------------------------------------------------------------------------------+
 | ``archive``             | url-path | The archive associated with the source package                                        |
 +-------------------------+----------+---------------------------------------------------------------------------------------+
-| ``package_name``        | string   | Name of the accepted source package if it available                                   |
+| ``package_name``        | string   | Name of the accepted source package if it is available                                |
 +-------------------------+----------+---------------------------------------------------------------------------------------+
-| ``package_version``     | string   | Name of the accepted source package if it available                                   |
+| ``package_version``     | string   | Name of the accepted source package if it is available                                |
 +-------------------------+----------+---------------------------------------------------------------------------------------+ 
 
 .. _binary-package-upload:


### PR DESCRIPTION
1) Mention the types of webhooks that can be configured on archives 
2) Describe their payloads
3) Modify the links for all webhooks to point to the manual