### PR TITLE
Fix pseudo-link and broken Twitter link to avoid linkcheck failure.

### DIFF
--- a/docs/user/how-to/import-ssh-keys.rst
+++ b/docs/user/how-to/import-ssh-keys.rst
@@ -138,7 +138,7 @@ are lost, use the ``-O resident`` option:
 
 Resident keys are useful if you use multiple machines or if you want a portable
 login method tied directly to your hardware key. To register a new key on your
-Launchpad account, visit https://launchpad.net/~username/+editsshkeys.
+Launchpad account, visit https://launchpad.net/~/+editsshkeys.
 
 These new key types offer strong protection against key theft and phishing, but
 require a physical device each time you connect. It is recommended you keep a

--- a/docs/user/reference/launchpad-and-community/feedback-on-launchpad.rst
+++ b/docs/user/reference/launchpad-and-community/feedback-on-launchpad.rst
@@ -18,7 +18,7 @@ Trouble logging into Launchpad? `get help for the Ubuntu Single Sign-on service 
 
 If you're having trouble logging into Launchpad, you can get help:
 
-Check the system `status page on Twitter <http://twitter.com/launchpadstatus>`_ for current known issues and details of any workarounds.
+Check the system `status page on Mastodon <https://ubuntu.social/@launchpadstatus>`_ for current known issues and details of any workarounds.
 
 Other issues
 ------------


### PR DESCRIPTION
Partially addresses recent linkcheck failures by:
- Coding out a pseudo-link that is not supposed to be clicked
- Replacing a Twitter link for LP status with a Mastodon link