### PR TITLE
Add two issue templates and a config file for github issues.

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/workflows/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/workflows/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,0 +1,33 @@
+name: Documentation issue
+about: Report issue related to the Launchpad documentation
+title: ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to report this issue!**
+        We appreciate your input, and it will help us improve the documentation.
+
+        Please provide an appropriate title at the top of this page.
+  - type: checkboxes
+  id: content
+  attributes:
+    label: Select an option
+    description: Please let us know what issue you encountered with the documentation.
+    options:
+      - label: I couldn't find what I was looking for
+      - label: I found the information, but it was incorrect
+      - label: I found the information, but it was incomplete
+      - label: I found the information, but it was confusing
+      - label: I encountered a technical issue (e.g., broken link, image not loading)
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue description
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true

--- a/.github/workflows/ISSUE_TEMPLATE/general-feedback-and-questions.md
+++ b/.github/workflows/ISSUE_TEMPLATE/general-feedback-and-questions.md
@@ -1,0 +1,25 @@
+name: General feedback and questions
+about: Give general feedback (kudos, suggestions, etc.), or ask questions about the Launchpad manual.
+title: ''
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to provide this feedback!**
+        We appreciate your input, and it will help us improve the documentation.
+
+        Please provide an appropriate title at the top of this page. To report 
+        a documentation issue on a specific page, please use our documentation 
+        issue form.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feedback
+      description: |
+        Please provide a detailed description of the issue:
+        - What part of the documentation were you trying to use?
+        - What did you expect to happen, and what actually happened?
+        - Any error messages or screenshots you can provide would be very helpful.
+    validations:
+      required: true


### PR DESCRIPTION
Adding issue templates will offer guidance to potential contributors and may also increase the quality of issues reported on the Launchpad manual.