### PR TITLE
Replace default feedback button to enable custom issue templates.

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,6 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Report Launchpad bugs
+    url: https://bugs.launchpad.net/launchpad/+filebug
+    about: Please report Launchpad bugs here
+    

--- a/docs/_static/issue_links.js
+++ b/docs/_static/issue_links.js
@@ -1,0 +1,28 @@
+// javascript snippet from: https://github.com/canonical/subiquity/blob/main/doc/_static/issue_links.js
+// if we already have an onload function, save that one
+var prev_handler = window.onload;
+
+window.onload = function onLoadHandler() {
+    // Prevent self-recursion
+    if (prev_handler && prev_handler !== onLoadHandler) {
+        prev_handler();
+    }
+
+    const link = document.createElement("a");
+    link.classList.add("muted-link");
+    link.classList.add("github-issue-link");
+    link.text = "Give feedback";
+    link.href = (
+        github_url
+        + "/issues/new/choose"
+    );
+    link.target = "_blank";
+
+    const div = document.createElement("div");
+    div.classList.add("github-issue-link-container");
+    div.append(link)
+
+    const container = document.querySelector(".article-container > .content-icon-container");
+    container.prepend(div);
+};
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -379,6 +379,7 @@ exclude_patterns = [
 
 html_js_files = [
     'js/bundle.js',
+    'issue_links.js',
 ]
 
 # Specifies a reST snippet to be appended to each .rst file
@@ -392,9 +393,9 @@ rst_epilog = """
 
 # Feedback button at the top; enabled by default
 #
-# TODO: To disable the button, uncomment this.
+# To disable the button, uncomment this.
 
-# disable_feedback_button = True
+disable_feedback_button = True
 
 
 # Your manpage URL


### PR DESCRIPTION
[PR 397](https://github.com/canonical/launchpad-manual/pull/397) adds two issue templates, but these are not picked up by the default ``Give feedback`` button. This pull request disables the default button and adds a feedback button that points to the correct issues template page on GitHub.

The issue templates are being introduced to improve the quality of issues reported and to reduce opening of spam issues.