### PR TITLE
Move issue templates into correct folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,0 +1,10 @@
+---
+name: Documentation issue
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/general-feedback.md
+++ b/.github/ISSUE_TEMPLATE/general-feedback.md
@@ -1,0 +1,10 @@
+---
+name: General feedback
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
Move ISSUE_TEMPLATE folder into correct folder. It is currently in the ``.github/workflows`` folder and is not getting picked up. It needs to be moved one level up into the ``.github`` folder.