### PR TITLE
Replace dead dev.lp.net link with feature highlights page link.

### DIFF
--- a/docs/developer/explanation/strategy.rst
+++ b/docs/developer/explanation/strategy.rst
@@ -193,4 +193,4 @@ References
 
 * :doc:`scope`
 * :doc:`values`
-* `Feature checklist <https://dev.launchpad.net/FeatureChecklist>`_
+* :ref:`Feature checklist <launchpad-feature-highlights>`


### PR DESCRIPTION
Replace dead dev.lp.net link with feature highlights page link.
Not an exact match for the content but is close enough.