### PR TITLE
Add amd64v3 as an option where architecture variants are listed.

### DIFF
--- a/docs/user/explanation/feature-highlights/index.rst
+++ b/docs/user/explanation/feature-highlights/index.rst
@@ -36,8 +36,8 @@ previous questions before asking new ones.
 ---------------------------------------------------
 Launchpad has a build farm consisting of 450+ builders (and counting), allowing
 users to build packages such as snaps, rocks, and charms on the platform. The 
-builders are distributed across various architectures including AMD64, ARM64, 
-RISC-V, and more.   
+builders are distributed across various architectures including AMD64, AMD64v3,
+ARM64, RISC-V, and more.   
 
 You can check the status of the builders, length of queues, and even build
 histories of individual builders, before starting yours. 

--- a/docs/user/how-to/packaging/build-oci-images-in-launchpad.rst
+++ b/docs/user/how-to/packaging/build-oci-images-in-launchpad.rst
@@ -85,7 +85,7 @@ Select build processors
 Launchpad supports multiple CPU architectures. To see which ones are available::
 
     >>> [processor.name for processor in lp.processors]
-    ['ia64', 'sparc', 'hppa', 'amd64', 'armel', 'armhf', 'lpia', 'ppc64el', 's390x', 'arm64', 'powerpc', 'i386', 'riscv64']
+    ['ia64', 'sparc', 'hppa', 'amd64', 'armel', 'armhf', 'lpia', 'ppc64el', 's390x', 'arm64', 'powerpc', 'amd64v3', 'i386', 'riscv64']
 
 To set processors on which your recipe will be built::
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -11,7 +11,7 @@ Launchpad gives you access to everything necessary to build and publish
 software including code hosting, issue tracking, and request tracking for bugs. 
 Features unique to this platform include build capacities for different 
 languages, and package formats for different architectures such as **AMD64**, 
-**ARM**, and **RISC-V**.
+**AMD64v3**, **ARM**, and **RISC-V**.
 
 Launchpad also offers tracking capabilities across issue trackers to 
 seamlessly communicate with upstream projects.

--- a/docs/user/reference/packaging/ppas/ppa.rst
+++ b/docs/user/reference/packaging/ppas/ppa.rst
@@ -42,8 +42,8 @@ Supported architectures
 When Launchpad builds a source package in a PPA, by default it creates
 binaries for amd64.
 
-You may also request builds for arm64, armhf, i386, powerpc, ppc64el, riscv64
-and/or s390x. Use the "Change details" page for the PPA to enable the
+You may also request builds for arm64, armhf, i386, powerpc, ppc64el, riscv64,
+amd64v3, and/or s390x. Use the "Change details" page for the PPA to enable the
 architectures you want.
 
 Changing the set of architectures for which a PPA builds does not create


### PR DESCRIPTION
AMD64v3 was added an option only where multiple architectures are discussed as options. It wasn't used to replace any existing architectures in examples where only one architecture was needed.