### PR TITLE
chores: Move PPA how-to guides from reference to how-to

### DIFF
--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -46,7 +46,7 @@ user/QuestionLifeCycle	user/reference/question-life-cycle/
 user/ProjectGroups	user/reference/project-groups/
 user/Packaging/SourceBuilds/Recipes	user/how-to/source-package-recipe/
 user/Packaging/SourceBuilds	user/explanation/packaging/packaging/
-user/Packaging/PPA/Deleting	user/reference/packaging/ppas/deleting-packages/
+user/Packaging/PPA/Deleting	user/how-to/packaging/deleting-packages/
 user/Legal	user/reference/launchpad-and-community/legal/launchpad-policies/
 #  user/InterBugTracking	https://web.archive.org/web/20120714093517/https://help.launchpad.net/Bugs/InterBugTracking (doc not migrated)
 user/Code/UploadingABranch	user/explanation/working-with-code/git-hosting

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -106,3 +106,5 @@ user/how-to/launchpad-api/launchpad-web/ user/explanation/launchpad-api/launchpa
 user/YourAccount/NewAccount user/how-to/account-management/create-account
 developer/how-to/getting developer/how-to/get-source-code/
 developer/how-to/debug-tests-with-visual-studio-code developer/how-to/debug-with-visual-studio-code
+user/reference/packaging/ppas/copying-packages/ user/how-to/packaging/copying-packages/
+user/reference/packaging/ppas/deleting-packages/ user/how-to/packaging/deleting-packages/

--- a/docs/user/how-to/packaging/copying-packages.rst
+++ b/docs/user/how-to/packaging/copying-packages.rst
@@ -4,14 +4,15 @@
 
 .. _copying-packages:
 
-Copying packages from PPAs
+Copy packages from PPAs
 ==========================
 
 You can copy packages from other PPAs into any PPA that you can upload
 to. You also have the option of copying packages between distro-series
 (i.e. different distribution releases).
 
-For example: take a look at the `Launchpad team's PPA copy packages <https://launchpad.net/~launchpad/+archive/ubuntu/ppa/+copy-packages>`_ page.
+For example: take a look at the `Launchpad team's PPA copy packages <https://launchpad.net/~launchpad/+archive/ubuntu/ppa/+copy-packages>`_
+page.
 
 Here you can:
 

--- a/docs/user/how-to/packaging/copying-packages.rst
+++ b/docs/user/how-to/packaging/copying-packages.rst
@@ -4,14 +4,12 @@
 
 .. _copying-packages:
 
-Copying packages
-================
-
-.. include:: /includes/important_not_revised_help.rst
+Copying packages from PPAs
+==========================
 
 You can copy packages from other PPAs into any PPA that you can upload
 to. You also have the option of copying packages between distro-series
-(i.e different distribution releases).
+(i.e. different distribution releases).
 
 For example: take a look at the `Launchpad team's PPA copy packages <https://launchpad.net/~launchpad/+archive/ubuntu/ppa/+copy-packages>`_ page.
 
@@ -36,11 +34,10 @@ Copy errors
 Version numbers need to be unique
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once a version number is used, you cannot reuse it for the same archive
-/ PPA.
+Once a version number is used, you cannot reuse it for the same archive or PPA.
 
 When you try to copy packages to an archive or a PPA where the version
-number already exists, you will see an error message as following:
+number already exists, you will see the following error message:
 
 ::
 

--- a/docs/user/how-to/packaging/deleting-packages.rst
+++ b/docs/user/how-to/packaging/deleting-packages.rst
@@ -4,26 +4,31 @@
 
 .. _package-deletion:
 
-Package deletion
-================
-
-.. include:: /includes/important_not_revised_help.rst
+Deleting packages from PPAs
+===========================
 
 You can delete any package from your PPA. However, it can take some time
 before the package is removed from the listing on your PPA overview page
 and the reported size of your archive is adjusted.
 
-The deletion page allows you to schedule packages for deletion. To do
-this, search first for the desired packages, select one or more of them,
-input a comment, and request deletion. Deletion will affect the source
-selected and any binary packages built from it.
+The deletion page allows you to schedule packages for deletion.
+To reach the page, first click on "View package details" on the PPA page
+and then on "Delete packages". In the menu, first search for the desired
+packages, select one or more of them, input a comment,
+and then request deletion. Deletion will affect the selected source package
+and any binary packages built from it.
 
 Deletion marks the packages as deleted in the UI, but they are actually
 removed from your PPA in separate steps:
 
-``Archive indexes:`` A deleted package disappears from the archive indexes in at most 20 minutes. As soon as this happens, users will no longer be able to install it via apt.
+- ``Archive indexes:`` A deleted package disappears from the archive indexes
+  in at most 20 minutes. As soon as this happens, users will no longer
+  be able to install it via apt.
 
-``Files on disk:`` A file will be removed from the archive disk pool only when all packages referencing it have been scheduled for deletion. This includes packages published in other series, or multiple package versions referring to the same original upstream tarball.
+- ``Files on disk:`` A file will be removed from the archive disk pool only
+  when all packages referencing it have been scheduled for deletion.
+  This includes packages published in other series,
+  or multiple package versions referring to the same original upstream tarball.
 
 The job that removes files from disk runs every six hours. It may take
 some time to remove a file from disk, depending on the number of

--- a/docs/user/how-to/packaging/deleting-packages.rst
+++ b/docs/user/how-to/packaging/deleting-packages.rst
@@ -4,7 +4,7 @@
 
 .. _package-deletion:
 
-Deleting packages from PPAs
+Delete packages from PPAs
 ===========================
 
 You can delete any package from your PPA. However, it can take some time

--- a/docs/user/how-to/packaging/index.rst
+++ b/docs/user/how-to/packaging/index.rst
@@ -19,3 +19,5 @@ Packaging
     build-charms-in-launchpad
     build-oci-images-in-launchpad
     use-ppa-snapshot-service
+    copying-packages
+    deleting-packages

--- a/docs/user/reference/packaging/ppas/index.rst
+++ b/docs/user/reference/packaging/ppas/index.rst
@@ -14,5 +14,3 @@ Personal package archives
 
     Personal Package Archive <ppa>
     Building a source package <building-a-source-package>
-    Copy packages <copying-packages>
-    Deleting packages <deleting-packages>


### PR DESCRIPTION
-   [x] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----

As discussed in the documentation session, the two pages ("Copying packages" and "Deleting packages") belong into the "how to" instead of the reference section.

I also did a few smaller stylistic edits.