### PR TITLE
launchpad doc to ref  edits.

### DIFF
--- a/docs/developer/explanation/architecture.rst
+++ b/docs/developer/explanation/architecture.rst
@@ -37,7 +37,7 @@ directly related to code structure or quality.
 Related documents
 -----------------
 
-The :doc:`Python style guide <../reference/python>` specifies coding style guidelines.
+The :ref:`Python style guide <python-style-guide>` specifies coding style guidelines.
 
 Values
 ======

--- a/docs/developer/explanation/branches.rst
+++ b/docs/developer/explanation/branches.rst
@@ -113,7 +113,7 @@ Where to send merge requests
 Merge requests that do any of the following should be targeted at the
 **db-devel** branch:
 
--  adds a cold database patch (see :doc:`../how-to/database-schema-changes-process`)
+-  adds a cold database patch (see :ref:`database-schema-changes-process`)
 -  depends on database schema change only in **db-devel** /
    **db-stable**
 

--- a/docs/developer/explanation/charms.rst
+++ b/docs/developer/explanation/charms.rst
@@ -2,6 +2,8 @@
    :description: Overview of Juju charm development principles and process for 
       Launchpad deployments.
 
+.. _charm-development:
+
 =================
 Charm development
 =================

--- a/docs/developer/explanation/code.rst
+++ b/docs/developer/explanation/code.rst
@@ -26,9 +26,9 @@ system. The major sub-systems are:
 -  Email processing
 -  Code imports (from CVS, Subversion, git and Mercurial)
 -  Branch source code browser (`cgit <https://git.zx2c4.com/cgit/>`__
-   for Git; :doc:`loggerhead <../how-to/land-update-for-loggerhead>` for Bazaar)
+   for Git; :ref:`loggerhead <landing-updates-for-loggerhead>` for Bazaar)
 -  Source package recipes (`git-build-recipe`/`bzr-builder\` integration
-   with :doc:`Soyuz ../how-to/use-soyuz-locally`)
+   with :ref:`Soyuz <how-to-use-soyuz-locally>`)
 
 Each of these subsystems also have multiple moving parts and some have
 other asynchronous jobs associated with them.
@@ -36,7 +36,7 @@ other asynchronous jobs associated with them.
 The `codehosting overview diagram :attachment:../images/codehosting.png`
 summarises how some of these systems interact.
 
-You can :doc:`run the codehosting system locally <../how-to/codehosting-locally>`.
+You can :ref:`run the codehosting system locally <how-to-use-codehosting-locally>`.
 
 We no longer put significant effort into bzr hosting beyond making sure
 it remains functional. The future of bzr is
@@ -210,7 +210,7 @@ branch.
 -  loggerhead itself - community project but with major contributions
    from Canonical
 
-See :doc:`Loggerhead for Launchpad developers <../how-to/land-update-for-loggerhead>` for details on
+See :ref:`Loggerhead for Launchpad developers <landing-updates-for-loggerhead>` for details on
 how to land changes to Launchpad loggerhead.
 
 Source package recipes

--- a/docs/developer/explanation/code.rst
+++ b/docs/developer/explanation/code.rst
@@ -26,9 +26,9 @@ system. The major sub-systems are:
 -  Email processing
 -  Code imports (from CVS, Subversion, git and Mercurial)
 -  Branch source code browser (`cgit <https://git.zx2c4.com/cgit/>`__
-   for Git; :ref:`loggerhead <landing-updates-for-loggerhead>` for Bazaar)
+   for Git; :ref:`loggerhead <land-updates-loggerhead>` for Bazaar)
 -  Source package recipes (`git-build-recipe`/`bzr-builder\` integration
-   with :ref:`Soyuz <how-to-use-soyuz-locally>`)
+   with :ref:`Soyuz <use-soyuz-locally>`)
 
 Each of these subsystems also have multiple moving parts and some have
 other asynchronous jobs associated with them.
@@ -36,7 +36,7 @@ other asynchronous jobs associated with them.
 The `codehosting overview diagram :attachment:../images/codehosting.png`
 summarises how some of these systems interact.
 
-You can :ref:`run the codehosting system locally <how-to-use-codehosting-locally>`.
+You can :ref:`run the codehosting system locally <use-codehosting-locally>`.
 
 We no longer put significant effort into bzr hosting beyond making sure
 it remains functional. The future of bzr is
@@ -210,7 +210,7 @@ branch.
 -  loggerhead itself - community project but with major contributions
    from Canonical
 
-See :ref:`Loggerhead for Launchpad developers <landing-updates-for-loggerhead>` for details on
+See :ref:`Loggerhead for Launchpad developers <land-updates-loggerhead>` for details on
 how to land changes to Launchpad loggerhead.
 
 Source package recipes

--- a/docs/developer/explanation/css-sprites.rst
+++ b/docs/developer/explanation/css-sprites.rst
@@ -2,7 +2,7 @@
    :description: Learn how to use CSS sprites in Launchpad templates for 
       improved website performance.
 
-.. _using-css-sprites:
+.. _use-css-sprites:
 
 Using CSS sprites
 =================

--- a/docs/developer/explanation/css-sprites.rst
+++ b/docs/developer/explanation/css-sprites.rst
@@ -2,6 +2,8 @@
    :description: Learn how to use CSS sprites in Launchpad templates for 
       improved website performance.
 
+.. _using-css-sprites:
+
 Using CSS sprites
 =================
 

--- a/docs/developer/explanation/css.rst
+++ b/docs/developer/explanation/css.rst
@@ -43,7 +43,7 @@ If you are dealing with sprites you may also have to run:
 
    make sprite_image
 
-:doc:`More info on sprites <css-sprites>`.
+:ref:`More info on sprites <using-css-sprites>`.
 
 Fonts
 -----

--- a/docs/developer/explanation/css.rst
+++ b/docs/developer/explanation/css.rst
@@ -43,7 +43,7 @@ If you are dealing with sprites you may also have to run:
 
    make sprite_image
 
-:ref:`More info on sprites <using-css-sprites>`.
+:ref:`More info on sprites <use-css-sprites>`.
 
 Fonts
 -----

--- a/docs/developer/explanation/database-performance.rst
+++ b/docs/developer/explanation/database-performance.rst
@@ -106,7 +106,7 @@ EXPLAIN ANALYZE on staging and qastaging can be used by LOSAs, the TAs,
 and squad leads.
 
 If you want to see how a query is working on a GET page locally, try the
-:doc:`++oops++ and ++profile++ tools <../how-to/debugging>`.
+:ref:`++oops++ and ++profile++ tools <debug-stories-pagetests>`.
 ++profile++ reportedly works on staging and qastaging now too.
 
 Unfortunately, they sometimes do not work properly for POSTs, and can't

--- a/docs/developer/explanation/hacking.rst
+++ b/docs/developer/explanation/hacking.rst
@@ -9,7 +9,7 @@ Hacking
 
 .. note::
 
-    Want to navigate the source tree? Look at :doc:`Navigating <navigating>`.
+    Want to navigate the source tree? Look at :ref:`Navigating <navigating-the-tree>`.
 
 Python programming
 ------------------
@@ -809,7 +809,7 @@ We use virtualenv and pip for our build system.
 Where can I read about it?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Also see the :doc:`explanation about our pip setup <pip>`.
+Also see the :ref:`explanation about our pip setup <launchpad-pip-integration>`.
 
 You can read more general information on https://pip.pypa.io/en/stable/.
 

--- a/docs/developer/explanation/images.rst
+++ b/docs/developer/explanation/images.rst
@@ -29,4 +29,4 @@ If you're dealing with sprites you will need to build the image:
 
    make sprite_image
 
-More info on :ref:`sprites <using-css-sprites>`.
+More info on :ref:`sprites <use-css-sprites>`.

--- a/docs/developer/explanation/images.rst
+++ b/docs/developer/explanation/images.rst
@@ -29,4 +29,4 @@ If you're dealing with sprites you will need to build the image:
 
    make sprite_image
 
-More info on :doc:`sprites <css-sprites>`.
+More info on :ref:`sprites <using-css-sprites>`.

--- a/docs/developer/explanation/javascript-integration-testing.rst
+++ b/docs/developer/explanation/javascript-integration-testing.rst
@@ -2,6 +2,8 @@
    :description: Understand JavaScript integration testing in Launchpad using 
       the yuitest library.
 
+.. _integration-testing-in-javascript:
+
 Integration testing in JavaScript
 =================================
 
@@ -10,7 +12,7 @@ We use the Graded Browser Support chart to determine which browser's code should
 be regularly tested in.
 
 Every JavaScript component should be tested first and foremost using
-:doc:`unit testing <javascript-unittesting>`.
+:ref:`unit testing <developing-with-yui-test>`.
 
 We have infrastructure to write tests centred on the integration
 between the JavaScript component and the app server (regular API or

--- a/docs/developer/explanation/javascript-unittesting.rst
+++ b/docs/developer/explanation/javascript-unittesting.rst
@@ -2,6 +2,8 @@
    :description: Introduction to using YUI.Test for JavaScript unit testing in 
       Launchpad.
 
+.. _developing-with-yui-test:
+
 Developing with YUI.Test
 ========================
 
@@ -151,6 +153,6 @@ correctly updated as a result of a user initiated action such as a
 button click. Sometimes, in production, such a user action may result in
 an XHR call where the response data is used to update the DOM. In such
 cases, you still want to be able to test the interaction within a YUI
-test without having to resort to using an :doc:`integration
-test <javascript-integration-testing>`. To make this easy we have the 
+test without having to resort to using an :ref:`integration
+test <integration-testing-in-javascript>`. To make this easy we have the 
 :ref:`MockIo class <mockio-library>` in Launchpad.

--- a/docs/developer/explanation/launchpad-ppa.rst
+++ b/docs/developer/explanation/launchpad-ppa.rst
@@ -158,4 +158,4 @@ In progress
 -  Focal (next, next production LTS?)
 
 When the supported series change, remember to also update
-:doc:`../how-to/get-source-code` and :doc:`../how-to/running`.
+:ref:`get-the-source-code` and :ref:`setting-up-and-running-launchpad-advanced`.

--- a/docs/developer/explanation/launchpad-ppa.rst
+++ b/docs/developer/explanation/launchpad-ppa.rst
@@ -158,4 +158,4 @@ In progress
 -  Focal (next, next production LTS?)
 
 When the supported series change, remember to also update
-:ref:`get-the-source-code` and :ref:`setting-up-and-running-launchpad-advanced`.
+:ref:`get-the-source-code` and :ref:`set-up-and-run-launchpad-advanced`.

--- a/docs/developer/explanation/live-patching.rst
+++ b/docs/developer/explanation/live-patching.rst
@@ -132,7 +132,7 @@ Table renaming
 
 Because code is being deployed separately from database updates, we need
 to maintain a fully updateable working alias for the old table name to
-the new table name. See :ref:`Rename Database Table <renaming-a-database-table>` for an example
+the new table name. See :ref:`Rename Database Table <rename-database-table>` for an example
 database patch.
 
 Adding columns

--- a/docs/developer/explanation/live-patching.rst
+++ b/docs/developer/explanation/live-patching.rst
@@ -132,7 +132,7 @@ Table renaming
 
 Because code is being deployed separately from database updates, we need
 to maintain a fully updateable working alias for the old table name to
-the new table name. See :doc:`Rename Database Table <../how-to/rename-database-table>` for an example
+the new table name. See :ref:`Rename Database Table <renaming-a-database-table>` for an example
 database patch.
 
 Adding columns

--- a/docs/developer/explanation/navigating.rst
+++ b/docs/developer/explanation/navigating.rst
@@ -8,7 +8,7 @@
 Navigating the tree
 ===================
 
-See :ref:`setting-up-and-running-launchpad-advanced` to learn how to get Launchpad's code and set up
+See :ref:`set-up-and-run-launchpad-advanced` to learn how to get Launchpad's code and set up
 a local development environment.
 
 The Launchpad tree is big, messy and changing.  Sorry about that.  Don't panic

--- a/docs/developer/explanation/navigating.rst
+++ b/docs/developer/explanation/navigating.rst
@@ -2,11 +2,13 @@
    :description: Navigate the Launchpad source tree with guidance on key 
       directories including bin, utilities, lib, and database folders.
 
+.. _navigating-the-tree:
+
 ===================
 Navigating the tree
 ===================
 
-See :doc:`../how-to/running` to learn how to get Launchpad's code and set up
+See :ref:`setting-up-and-running-launchpad-advanced` to learn how to get Launchpad's code and set up
 a local development environment.
 
 The Launchpad tree is big, messy and changing.  Sorry about that.  Don't panic

--- a/docs/developer/explanation/performance.rst
+++ b/docs/developer/explanation/performance.rst
@@ -73,7 +73,7 @@ in order to avoid querying the database more often then necessary.
 
 When changing code, it can easily happen to increase the query count. You can
 avoid this by using a helper to
-:ref:`preserve query count <preserving-query-count>`.
+:ref:`preserve query count <preserve-query-count>`.
 
 When you face performance or even timeout issues, you should learn more about
 `timeout analysis`_ (internal video).

--- a/docs/developer/explanation/performance.rst
+++ b/docs/developer/explanation/performance.rst
@@ -73,7 +73,7 @@ in order to avoid querying the database more often then necessary.
 
 When changing code, it can easily happen to increase the query count. You can
 avoid this by using a helper to
-:doc:`preserve query count <../how-to/preserve-query-count>`.
+:ref:`preserve query count <preserving-query-count>`.
 
 When you face performance or even timeout issues, you should learn more about
 `timeout analysis`_ (internal video).

--- a/docs/developer/explanation/pip.rst
+++ b/docs/developer/explanation/pip.rst
@@ -2,6 +2,8 @@
    :description: Understand Launchpad's pip integration for managing Python 
       packages including setup, usage, and dependency management.
 
+.. _launchpad-pip-integration:
+
 Launchpad pip integration
 *************************
 
@@ -268,7 +270,7 @@ Let's suppose that we want to add the "lazr.foo" package as a dependency.
 8.  Check old versions in the download-cache.  If you are sure that
     they are not in use any more, *anywhere*, then remove them to save
     checkout space.  More explicitly, check with the LOSAs to see if
-    they are in use in production and :ref:`contact the Launchpad team<get-help>` 
+    they are in use in production and :ref:`contact the Launchpad team <get-help>` 
     before deleting anything if you are unsure.  A rule of thumb is that it's 
     worth starting this investigation if the replacement has already been in 
     use by the Launchpad tree for more than a month. You can approximate this

--- a/docs/developer/explanation/pre-merge-reviews.rst
+++ b/docs/developer/explanation/pre-merge-reviews.rst
@@ -50,7 +50,7 @@ Working with PreMergeReviews
 For pre-merge reviews to be effective, however, small modifications to
 the development workflow are required. The main modification is, of
 course, requesting peer review of your code changes before merging your
-code into :doc:`Trunk <branches>`. The sections below go into the details
+code into :ref:`Trunk <about-launchpad-branches>`. The sections below go into the details
 of how this is best performed. There is a crib sheet for getting a
 branch merged on the WorkingWithReviews page.
 

--- a/docs/developer/explanation/running-details.rst
+++ b/docs/developer/explanation/running-details.rst
@@ -2,6 +2,8 @@
    :description: Understand what happens when you use the rocketfuel-setup 
       script to set up a local instance of Launchpad.
 
+.. _launchpad-installation-details:
+
 ==============================
 Launchpad installation details
 ==============================

--- a/docs/developer/explanation/scope.rst
+++ b/docs/developer/explanation/scope.rst
@@ -341,6 +341,6 @@ Downstream
 References
 ==========
 
-* :doc:`strategy`
-* :doc:`values`
+* :ref:`launchpad-strategy`
+* :ref:`launchpad-values`
 * :ref:`Feature highlights <launchpad-feature-highlights>`

--- a/docs/developer/explanation/security.rst
+++ b/docs/developer/explanation/security.rst
@@ -76,7 +76,7 @@ especially important given the interactions between visibility and mutability
 rules of multiple objects found on many Launchpad pages.
 
 You can learn more about how we use it in
-:ref:`Handling security policies <handling-security-policies>`.
+:ref:`Handling security policies <handle-security-policies>`.
 
 Permissions
 -----------

--- a/docs/developer/explanation/security.rst
+++ b/docs/developer/explanation/security.rst
@@ -19,7 +19,7 @@ fundamentally secure.
 
 We only use Ubuntu LTS releases, which gets professional security support.
 
-We monitor updates of both system and :doc:`Python packages <pip>` closely,
+We monitor updates of both system and :ref:`Python packages <launchpad-pip-integration>` closely,
 and update or patch our systems and applications accordingly.
 
 We use a restrictive network setup between all our systems, especially
@@ -76,7 +76,7 @@ especially important given the interactions between visibility and mutability
 rules of multiple objects found on many Launchpad pages.
 
 You can learn more about how we use it in
-:doc:`Handling security policies <../how-to/security>`.
+:ref:`Handling security policies <handling-security-policies>`.
 
 Permissions
 -----------

--- a/docs/developer/explanation/strategy.rst
+++ b/docs/developer/explanation/strategy.rst
@@ -3,6 +3,8 @@
       best OS by improving Canonical's productivity and open source development 
       efficiency.
 
+.. _launchpad-strategy:
+
 ==================
 Launchpad strategy
 ==================
@@ -196,6 +198,6 @@ than many open source and even proprietary projects.
 References
 ==========
 
-* :doc:`scope`
-* :doc:`values`
+* :ref:`what-is-launchpad`
+* :ref:`launchpad-values`
 * :ref:`Feature checklist <launchpad-feature-highlights>`

--- a/docs/developer/explanation/values.rst
+++ b/docs/developer/explanation/values.rst
@@ -2,6 +2,8 @@
    :description: Understand the values behind Launchpad; why certain decisions
       were made, and why things are implemented as they are.
 
+.. _launchpad-values:
+
 ================
 Launchpad values
 ================
@@ -10,9 +12,9 @@ Whenever we are thinking about what Launchpad should be, or how we should
 implement a change, or whether something is a good idea or not, we have
 recourse to three distinct sets of guidelines.
 
-The first is :doc:`strategy`, which reminds us why we are making Launchpad and
+The first is :ref:`launchpad-strategy`, which reminds us why we are making Launchpad and
 helps us answer questions such as "How does this help Launchpad meet its
-goals?".  The second is :doc:`scope`, which helps us answer questions like "Is
+goals?".  The second is :ref:`what-is-launchpad`, which helps us answer questions like "Is
 this in scope?".  Together, they sort out the 'matter' of Launchpad.
 
 The third is this document, the Launchpad Values.  It tries to address the
@@ -20,7 +22,7 @@ The third is this document, the Launchpad Values.  It tries to address the
 you.  Rather, it will rule out certain options and decisions before they are
 even considered.
 
-Like the :doc:`strategy`, this document is living: it should be changed and
+Like the :ref:`launchpad-strategy`, this document is living: it should be changed and
 improved as we learn more about how to make Launchpad.  It is also
 aspirational: not all of Launchpad lives up to these values.
 
@@ -172,5 +174,5 @@ then sent back to the upstream.
 References
 ==========
 
-* :doc:`strategy`
-* :doc:`scope`
+* :ref:`launchpad-strategy`
+* :ref:`what-is-launchpad`

--- a/docs/developer/explanation/working-with-db-devel.rst
+++ b/docs/developer/explanation/working-with-db-devel.rst
@@ -15,7 +15,7 @@ Alternative trunk
 -----------------
 
 Check out the \`db-devel\` branch in your :ref:`existing git
-clone <setting-up-and-running-launchpad-advanced>`:
+clone <set-up-and-run-launchpad-advanced>`:
 
 ::
 

--- a/docs/developer/explanation/working-with-db-devel.rst
+++ b/docs/developer/explanation/working-with-db-devel.rst
@@ -14,8 +14,8 @@ changes <https://dev.launchpad.net/PolicyAndProcess/DatabaseSchemaChangesProcess
 Alternative trunk
 -----------------
 
-Check out the \`db-devel\` branch in your :doc:`existing git
-clone <../how-to/running>`:
+Check out the \`db-devel\` branch in your :ref:`existing git
+clone <setting-up-and-running-launchpad-advanced>`:
 
 ::
 

--- a/docs/developer/how-to/codehosting-locally.rst
+++ b/docs/developer/how-to/codehosting-locally.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Set up and run the complete Bazaar codehosting stack locally.
 
+.. _how-to-use-codehosting-locally:
+
 How to use codehosting locally
 ==============================
 

--- a/docs/developer/how-to/codehosting-locally.rst
+++ b/docs/developer/how-to/codehosting-locally.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: Set up and run the complete Bazaar codehosting stack locally.
 
-.. _how-to-use-codehosting-locally:
+.. _use-codehosting-locally:
 
 How to use codehosting locally
 ==============================

--- a/docs/developer/how-to/contributing-changes.rst
+++ b/docs/developer/how-to/contributing-changes.rst
@@ -52,7 +52,7 @@ Create a branch from a reasonable point, such as ``master``.
     git checkout -b <descriptive-branch-name>
 
 Make your changes on the branch. Be sure to test them locally by setting up a
-local :doc:`Launchpad development instance <running>`.
+local :ref:`Launchpad development instance <setting-up-and-running-launchpad-advanced>`.
 
 When it comes to commit messages, please follow these guidelines:
 
@@ -77,7 +77,7 @@ Commit body
 Run the pre-commit hook
 -----------------------
 
-If you followed the instructions to :doc:`set up and run Launchpad <running>`,
+If you followed the instructions to :ref:`set up and run Launchpad <setting-up-and-running-launchpad-advanced>`,
 you should already have ``pre-commit`` installed and have the
 :ref:`pre-commit git hook <pre-commit>` installed. If not, complete these steps
 before proceeding.

--- a/docs/developer/how-to/contributing-changes.rst
+++ b/docs/developer/how-to/contributing-changes.rst
@@ -52,7 +52,7 @@ Create a branch from a reasonable point, such as ``master``.
     git checkout -b <descriptive-branch-name>
 
 Make your changes on the branch. Be sure to test them locally by setting up a
-local :ref:`Launchpad development instance <setting-up-and-running-launchpad-advanced>`.
+local :ref:`Launchpad development instance <set-up-and-run-launchpad-advanced>`.
 
 When it comes to commit messages, please follow these guidelines:
 
@@ -77,7 +77,7 @@ Commit body
 Run the pre-commit hook
 -----------------------
 
-If you followed the instructions to :ref:`set up and run Launchpad <setting-up-and-running-launchpad-advanced>`,
+If you followed the instructions to :ref:`set up and run Launchpad <set-up-and-run-launchpad-advanced>`,
 you should already have ``pre-commit`` installed and have the
 :ref:`pre-commit git hook <pre-commit>` installed. If not, complete these steps
 before proceeding.

--- a/docs/developer/how-to/database-schema-changes-process.rst
+++ b/docs/developer/how-to/database-schema-changes-process.rst
@@ -13,7 +13,7 @@ Step-by-step procedure
 ----------------------
 
 1. Prepare a branch containing just :ref:`your database
-   patch <making-a-database-patch>` for review.
+   patch <make-a-database-patch>` for review.
 
    -  The patch must either be a hot patch (function / trigger / index)
       or a cold patch (model change / model change + function/trigger).
@@ -91,9 +91,9 @@ they will be promoted to ``master`` as part of the go-live process.
 Hot patches
 ~~~~~~~~~~~
 
-:ref:`live-database-patching` explains how
-hot-patching works and what sorts of things we can hot-patch. It's the
-authority — we may be able to hot-patch more as our tooling improves.
+:ref:`live-database-patching` explains how hot-patching works and what sorts of 
+things we can hot-patch. It's the authority — we may be able to hot-patch more 
+as our tooling improves.
 
 Cold patches
 ~~~~~~~~~~~~
@@ -152,7 +152,7 @@ deployments, **no-one should use a -0 patch.**
 Instructions for choosing a patch number are in the docs in the
 dbpatches repository.
 
-.. _making-a-database-patch:
+.. _make-a-database-patch:
 
 Making a database patch
 -----------------------

--- a/docs/developer/how-to/database-schema-changes-process.rst
+++ b/docs/developer/how-to/database-schema-changes-process.rst
@@ -2,6 +2,8 @@
    :description: Comprehensive step-by-step guide for making database schema 
       changes in Launchpad using hot and cold patches.
 
+.. _database-schema-changes-process:
+
 Database schema changes process
 ===============================
 
@@ -10,8 +12,8 @@ Database schema changes process
 Step-by-step procedure
 ----------------------
 
-1. Prepare a branch containing just `your database
-   patch <#Making_a_database_patch>`__ for review.
+1. Prepare a branch containing just :ref:`your database
+   patch <making-a-database-patch>` for review.
 
    -  The patch must either be a hot patch (function / trigger / index)
       or a cold patch (model change / model change + function/trigger).
@@ -89,7 +91,7 @@ they will be promoted to ``master`` as part of the go-live process.
 Hot patches
 ~~~~~~~~~~~
 
-:doc:`../explanation/live-patching` explains how
+:ref:`live-database-patching` explains how
 hot-patching works and what sorts of things we can hot-patch. It's the
 authority — we may be able to hot-patch more as our tooling improves.
 
@@ -149,6 +151,8 @@ deployments, **no-one should use a -0 patch.**
 
 Instructions for choosing a patch number are in the docs in the
 dbpatches repository.
+
+.. _making-a-database-patch:
 
 Making a database patch
 -----------------------

--- a/docs/developer/how-to/debug-buildfarm-builder.rst
+++ b/docs/developer/how-to/debug-buildfarm-builder.rst
@@ -82,7 +82,7 @@ Cowboy builder
 
 .. tip::
 
-   Either :ref:`disable<disable-builder>` or switch to manual every
+   Either :ref:`disable <disable-builder>` or switch to manual every
    builder in the same architecture except one, and make the cowboy on that
    builder only. Otherwise, the location of the next triggered build will be
    randomized.

--- a/docs/developer/how-to/debug-with-visual-studio-code.rst
+++ b/docs/developer/how-to/debug-with-visual-studio-code.rst
@@ -14,7 +14,7 @@ SSH access to LXD containers within VS Code
 
 To run and debug Launchpad tests inside a local LXD container using Visual
 Studio Code, you need to set up SSH access. This guide assumes that SSH has been
-configured as described in the :ref:`Running <setting-up-and-running-launchpad-advanced>` section.
+configured as described in the :ref:`Running <set-up-and-run-launchpad-advanced>` section.
 
 1. **Install the SSH Extension**: Install the 'Remote - SSH' extension from the
    VS Code marketplace to enable SSH capabilities within your development

--- a/docs/developer/how-to/debugging.rst
+++ b/docs/developer/how-to/debugging.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Debug Launchpad pagetests using pdb breakpoints.
 
+.. _debug-stories-pagetests:
+
 Debug stories/pagetests
 =======================
 

--- a/docs/developer/how-to/develop-with-buildd.rst
+++ b/docs/developer/how-to/develop-with-buildd.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: How to develop with Buildd using LXD VM.
 
-.. _how-to-develop-with-buildd:
+.. _develop-with-buildd:
 
 How to develop with Buildd
 ==========================
@@ -265,7 +265,7 @@ First, you'll need to run some extra bits in Launchpad:
 Image setup
 -----------
 
-Consult the 'Launchpad Configuration' section of :ref:`how-to-use-soyuz-locally` to do the correct ``manage-chroot`` dance to register an image with launchpad. Without this, you will have no valid buildable architectures.
+Consult the 'Launchpad Configuration' section of :ref:`use-soyuz-locally` to do the correct ``manage-chroot`` dance to register an image with launchpad. Without this, you will have no valid buildable architectures.
 
 User setup
 ----------

--- a/docs/developer/how-to/develop-with-buildd.rst
+++ b/docs/developer/how-to/develop-with-buildd.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: How to develop with Buildd using LXD VM.
 
+.. _how-to-develop-with-buildd:
+
 How to develop with Buildd
 ==========================
 
@@ -263,7 +265,7 @@ First, you'll need to run some extra bits in Launchpad:
 Image setup
 -----------
 
-Consult the 'Launchpad Configuration' section of :doc:`use-soyuz-locally` to do the correct ``manage-chroot`` dance to register an image with launchpad. Without this, you will have no valid buildable architectures.
+Consult the 'Launchpad Configuration' section of :ref:`how-to-use-soyuz-locally` to do the correct ``manage-chroot`` dance to register an image with launchpad. Without this, you will have no valid buildable architectures.
 
 User setup
 ----------

--- a/docs/developer/how-to/get-source-code.rst
+++ b/docs/developer/how-to/get-source-code.rst
@@ -22,8 +22,8 @@ Launchpad is a core of service-specific code surrounding various third-party
 libraries.
 
 The process of building Launchpad locally requires a number of steps. You can
-follow the quick start instructions in :ref:`Running <setting-up-and-running-launchpad-quickstart>` or
-the advanced instructions in :ref:`Running <setting-up-and-running-launchpad-advanced>`.
+follow the quick start instructions in :ref:`Running <set-up-and-run-launchpad-quickstart>` or
+the advanced instructions in :ref:`Running <set-up-and-run-launchpad-advanced>`.
 
 
 Clone the repository

--- a/docs/developer/how-to/get-source-code.rst
+++ b/docs/developer/how-to/get-source-code.rst
@@ -22,8 +22,8 @@ Launchpad is a core of service-specific code surrounding various third-party
 libraries.
 
 The process of building Launchpad locally requires a number of steps. You can
-follow the quick start instructions in :doc:`Running <running-quickstart>` or
-the advanced instructions in :doc:`Running <running>`.
+follow the quick start instructions in :ref:`Running <setting-up-and-running-launchpad-quickstart>` or
+the advanced instructions in :ref:`Running <setting-up-and-running-launchpad-advanced>`.
 
 
 Clone the repository

--- a/docs/developer/how-to/land-update-for-loggerhead.rst
+++ b/docs/developer/how-to/land-update-for-loggerhead.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: How to land updates for the Loggerhead Bazaar code browser.
 
+.. _landing-updates-for-loggerhead:
+
 Landing updates for Loggerhead
 ==============================
 

--- a/docs/developer/how-to/land-update-for-loggerhead.rst
+++ b/docs/developer/how-to/land-update-for-loggerhead.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: How to land updates for the Loggerhead Bazaar code browser.
 
-.. _landing-updates-for-loggerhead:
+.. _land-updates-loggerhead:
 
 Landing updates for Loggerhead
 ==============================

--- a/docs/developer/how-to/manage-users.rst
+++ b/docs/developer/how-to/manage-users.rst
@@ -24,8 +24,8 @@ and run: ``utilities/make-lp-user test-user``.
 Staging/qastaging
 ~~~~~~~~~~~~~~~~~
 
-Some development environments, such as those deployed using the :doc:`Mojo
-spec <../explanation/charms>`, use production Single Sign-On for
+Some development environments, such as those deployed using the :ref:`Mojo
+spec <charm-development>`, use production Single Sign-On for
 authentication.  In these environments, you should not use
 ``utilities/make-lp-user``; instead, log into 
 ``https://{qastaging,staging}.launchpad.net/`` via SSO as you would on 

--- a/docs/developer/how-to/preserve-query-count.rst
+++ b/docs/developer/how-to/preserve-query-count.rst
@@ -2,7 +2,7 @@
    :description: Ensure constant database query counts when reading or creating 
       multiple items.
 
-.. _preserving-query-count:
+.. _preserve-query-count:
 
 ======================
 Preserving query count

--- a/docs/developer/how-to/preserve-query-count.rst
+++ b/docs/developer/how-to/preserve-query-count.rst
@@ -2,6 +2,8 @@
    :description: Ensure constant database query counts when reading or creating 
       multiple items.
 
+.. _preserving-query-count:
+
 ======================
 Preserving query count
 ======================

--- a/docs/developer/how-to/rename-database-table.rst
+++ b/docs/developer/how-to/rename-database-table.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: How to rename database tables in Launchpad.
 
+.. _renaming-a-database-table:
+
 =========================
 Renaming a database table
 =========================

--- a/docs/developer/how-to/rename-database-table.rst
+++ b/docs/developer/how-to/rename-database-table.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: How to rename database tables in Launchpad.
 
-.. _renaming-a-database-table:
+.. _rename-database-table:
 
 =========================
 Renaming a database table

--- a/docs/developer/how-to/running-quickstart.rst
+++ b/docs/developer/how-to/running-quickstart.rst
@@ -2,7 +2,7 @@
    :description: Quick guide to setting up and running Launchpad for 
       development.
 
-.. _setting-up-and-running-launchpad-quickstart:
+.. _set-up-and-run-launchpad-quickstart:
 
 =============================================
 Setting up and running Launchpad (quickstart)

--- a/docs/developer/how-to/running-quickstart.rst
+++ b/docs/developer/how-to/running-quickstart.rst
@@ -19,7 +19,7 @@ own machine, using a `LXD
 `install <https://canonical.com/lxd/install>`_ LXD as a snap. 
 
 After you've done this, you may want to read about
-:doc:`../explanation/navigating`.
+:ref:`navigating-the-tree`.
 
 Supported operating systems
 ===========================

--- a/docs/developer/how-to/running.rst
+++ b/docs/developer/how-to/running.rst
@@ -17,7 +17,7 @@ own machine, using a `LXD
 isolate it from the rest of your system.
 
 After you've done this, you may want to read about
-:doc:`../explanation/navigating`.
+:ref:`navigating-the-tree`.
 
 .. _supported_operating_systems:
 
@@ -177,7 +177,7 @@ Then:
    $ curl https://git.launchpad.net/launchpad/plain/utilities/rocketfuel-setup >rocketfuel-setup
 
 Read through the rocketfuel-setup script at this point and make sure you're
-OK with what it's going to do.  (See :doc:`../explanation/running-details` if you want to
+OK with what it's going to do.  (See :ref:`launchpad-installation-details` if you want to
 know more.)
 
 .. code-block:: shell-session
@@ -362,7 +362,7 @@ self-signed certificate. You can log in as ``admin@canonical.com`` without
 a password. (This is only for development convenience, and assumes that you
 trust machines that can route to your LXD containers; of course a production
 deployment would need real authentication.). If you want to create more user
-accounts, see :doc:`./manage-users`.
+accounts, see :ref:`manage-users-and-teams-in-development-environments`.
 
 Accessing launchpad.test from a single host over SSH
 ----------------------------------------------------
@@ -450,7 +450,7 @@ Email
 Development Launchpads don't send email to the outside world, for obvious
 reasons.  They connect to the local SMTP server and send to root.  To create
 new users, create a new account and check the local mailbox, or see
-:doc:`./manage-users`.
+:ref:`manage-users-and-teams-in-development-environments`.
 
 .. _database-permissions:
 

--- a/docs/developer/how-to/running.rst
+++ b/docs/developer/how-to/running.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: Advanced guide to setting up and running Launchpad.
 
-.. _setting-up-and-running-launchpad-advanced:
+.. _set-up-and-run-launchpad-advanced:
 
 Setting up and running Launchpad (advanced)
 ===========================================

--- a/docs/developer/how-to/security.rst
+++ b/docs/developer/how-to/security.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: Guide on implementing security policies in Launchpad.
 
-.. _handling-security-policies:
+.. _handle-security-policies:
 
 Handling security policies
 ==========================

--- a/docs/developer/how-to/security.rst
+++ b/docs/developer/how-to/security.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Guide on implementing security policies in Launchpad.
 
+.. _handling-security-policies:
+
 Handling security policies
 ==========================
 

--- a/docs/developer/how-to/triage-bugs.rst
+++ b/docs/developer/how-to/triage-bugs.rst
@@ -143,7 +143,7 @@ Selecting bugs to work on
 If you are working on Launchpad in your own time you'll most likely want
 to fix those bugs that matter to you, regardless of what importance the
 Launchpad project gives them. That's great and we welcome all bug fixes;
-we encourage you to look at :doc:`our page about fixing bugs <fixing-bugs>` first.
+we encourage you to look at :ref:`our page about fixing bugs <fixing-bugs>` first.
 
 Members of Canonical's Launchpad team will select bugs as seems
 appropriate to them.

--- a/docs/developer/how-to/use-soyuz-locally.rst
+++ b/docs/developer/how-to/use-soyuz-locally.rst
@@ -1,7 +1,7 @@
 .. meta::
    :description: Set up and use Soyuz locally for package building and testing.
 
-.. _how-to-use-soyuz-locally:
+.. _use-soyuz-locally:
 
 How to use Soyuz locally
 ========================
@@ -39,7 +39,8 @@ Set up a builder
 Set up for development
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you are intending to do any development on ``launchpad-buildd`` or similar, you possibly want :ref:`how-to-develop-with-buildd`.
+If you are intending to do any development on ``launchpad-buildd`` or similar, 
+you possibly want to :ref:`develop-with-buildd`.
 
 Installation
 ^^^^^^^^^^^^

--- a/docs/developer/how-to/use-soyuz-locally.rst
+++ b/docs/developer/how-to/use-soyuz-locally.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Set up and use Soyuz locally for package building and testing.
 
+.. _how-to-use-soyuz-locally:
+
 How to use Soyuz locally
 ========================
 
@@ -37,7 +39,7 @@ Set up a builder
 Set up for development
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you are intending to do any development on ``launchpad-buildd`` or similar, you possibly want :doc:`develop-with-buildd`.
+If you are intending to do any development on ``launchpad-buildd`` or similar, you possibly want :ref:`how-to-develop-with-buildd`.
 
 Installation
 ^^^^^^^^^^^^

--- a/docs/developer/how-to/use-updated-dependency.rst
+++ b/docs/developer/how-to/use-updated-dependency.rst
@@ -17,4 +17,4 @@ you need to both download the dependency and make a new build:
 Further reading
 ***************
 
-Please see :doc:`../explanation/pip`.
+Please see :ref:`launchpad-pip-integration`.

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -24,7 +24,7 @@ In this documentation
 ==========================             ==================
 
 ==========================             ==================
-**Setting up Launchpad:**              :ref:`Get the source code <get-the-source-code>` • :ref:`Quick set up <setting-up-and-running-launchpad-quickstart>` • :ref:`Advanced set up <setting-up-and-running-launchpad-advanced>`
+**Setting up Launchpad:**              :ref:`Get the source code <get-the-source-code>` • :ref:`Quick set up <set-up-and-run-launchpad-quickstart>` • :ref:`Advanced set up <set-up-and-run-launchpad-advanced>`
 
 **Operating Launchpad:**               :ref:`Manage users and teams <manage-users-and-teams-in-development-environments>` • :ref:`Using lp-shell <how-to-use-lp-shell>`
 

--- a/docs/developer/reference/python.rst
+++ b/docs/developer/reference/python.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Python coding style guide for Launchpad development.
 
+.. _python-style-guide:
+
 ==================
 Python style guide
 ==================
@@ -37,7 +39,7 @@ Related documents
 * `Exception guidelines <https://dev.launchpad.net/ExceptionGuidelines>`_
 * :ref:`Assertions <assertions-in-launchpad>`
 * `Launchpad hacking FAQ <https://dev.launchpad.net/LaunchpadHackingFAQ>`_
-* :doc:`Tests style guide <tests>`
+* :ref:`Tests style guide <tests-style-guide>`
 
 Formatting
 ==========

--- a/docs/developer/reference/services/build-farm.rst
+++ b/docs/developer/reference/services/build-farm.rst
@@ -2,6 +2,8 @@
    :description: Reference doc linking to resources related to the Launchpad 
       build farm including documentation, git repositories, and bug trackers.
 
+.. _build-farm:
+
 Build farm
 ==========
 
@@ -37,7 +39,7 @@ package builds, ``snapcraft`` for snap builds, etc.
 Builders do not have direct access to the Internet, but rather need to
 acquire an authentication token to be able to access a restricted set of
 URLs on the Internet via a proxy. This can either be a squid proxy or the
-:doc:`fetch service <fetch-service>`, determined by a ``use_fetch_service``
+:ref:`fetch service <fetch-service>`, determined by a ``use_fetch_service``
 flag. Currently, the fetch service can only be used for building snaps, charms,
 rocks and sourcecraft packages.
 
@@ -133,7 +135,7 @@ builder-proxy (squid)
 fetch-service
 ^^^^^^^^^^^^^
 
-See :doc:`Fetch Service <fetch-service>` logs section.
+See :ref:`Fetch Service <fetch-service>` logs section.
 
 
 Staging
@@ -164,7 +166,7 @@ builder-proxy (squid)
 fetch-service
 ^^^^^^^^^^^^^
 
-See :doc:`Fetch Service <fetch-service>` logs section.
+See :ref:`Fetch Service <fetch-service>` logs section.
 
 Monitoring
 ----------

--- a/docs/developer/reference/services/fetch-service.rst
+++ b/docs/developer/reference/services/fetch-service.rst
@@ -2,6 +2,8 @@
    :description: Reference document for the Fetch service. Provides links to 
       logs, git repositories, documentation, etc.
 
+.. _fetch-service:
+
 Fetch service
 =============
 
@@ -13,7 +15,7 @@ proxy. When used, it keeps track of requests and dependencies for the build.
 Detailed description
 --------------------
 The fetch service is a proxy service used by Launchpad builders (see
-:doc:`Build Farm <build-farm>`) that keeps track of dependencies downloaded
+:ref:`Build Farm <build-farm>`) that keeps track of dependencies downloaded
 during a build. This ensures developers have a trustworthy record of all the
 parts that make up the software being built.
 

--- a/docs/developer/reference/tests.rst
+++ b/docs/developer/reference/tests.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Summary of conventions for Launchpad Tests. 
 
+.. _tests-style-guide:
+
 =================
 Tests style guide
 =================
@@ -89,8 +91,8 @@ Common conventions
 
 The basic conventions for testable documentation are:
 
-* Example code is wrapped at 78 columns, follows the regular :doc:`Python
-  style guide <python>`, and is indented 4 spaces.
+* Example code is wrapped at 78 columns, follows the regular :ref:`Python
+  style guide <python-style-guide>`, and is indented 4 spaces.
 * Narrative text may be wrapped at either 72 or 78 columns.
 * You can use regular Python comments for explanations related to the code
   and not to the documentation.
@@ -480,8 +482,8 @@ prefer this:
         foo="expected",
         bar="more expected"))
 
-In general, you should follow Launchpad coding conventions (see :doc:`Python
-style guide <python>`), however when naming test methods:
+In general, you should follow Launchpad coding conventions (see :ref:`Python
+style guide <python-style-guide>`), however when naming test methods:
 
 * Use PEP 8 names, e.g. ``test_for_my_feature()``
 * When testing a specific Launchpad method, a mix of PEP 8 and camel case is

--- a/docs/developer/tutorials/creating-a-page-in-launchpad.rst
+++ b/docs/developer/tutorials/creating-a-page-in-launchpad.rst
@@ -11,7 +11,7 @@ greeting from a specific user. This will be available at ``/~username/+hello``.
 Pre-requisites
 ==============
 
-You have the :doc:`Launchpad development environment set up <../how-to/running>`.
+You have the :ref:`Launchpad development environment set up <setting-up-and-running-launchpad-advanced>`.
 
 Introduction
 ============

--- a/docs/developer/tutorials/creating-a-page-in-launchpad.rst
+++ b/docs/developer/tutorials/creating-a-page-in-launchpad.rst
@@ -11,7 +11,7 @@ greeting from a specific user. This will be available at ``/~username/+hello``.
 Pre-requisites
 ==============
 
-You have the :ref:`Launchpad development environment set up <setting-up-and-running-launchpad-advanced>`.
+You have the :ref:`Launchpad development environment set up <set-up-and-run-launchpad-advanced>`.
 
 Introduction
 ============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ In this manual
 
 ==========================    ===========================
 **User quick start:**         :ref:`Get started with launchpad <get-started-with-launchpad>`    • :ref:`Host a repository <hosting-git-repositories>` • :ref:`Community<help-the-community>` 
-**Developer quick start:**    :ref:`What is Launchpad<what-is-launchpad>`             • :ref:`Setting up Launchpad<setting-up-and-running-launchpad-quickstart>` • :ref:`Get the source code<get-the-source-code>`
+**Developer quick start:**    :ref:`What is Launchpad<what-is-launchpad>`             • :ref:`Setting up Launchpad<set-up-and-run-launchpad-quickstart>` • :ref:`Get the source code<get-the-source-code>`
 ==========================    ===========================
 
 The Launchpad manual is divided into two sections, according to the user:


### PR DESCRIPTION
-   [x] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Issue #335

I ran all CI checks.  The linkcheck CI returned a -rate limited- sleeping message caused by a URL in what appears to be:  /docs/user/reference/translations/language-specific-guides .
Address in question is: http://bestpractical.com/rt
I could not diagnose this, but this was not the section of the Launchpad Manual that I worked on.

This pull addresses all .rst files contained in the developer section. I replaced all :doc: with :ref: where shown and added target label as needed. I tested all internal links in every .rst document under developer. Internal links all appear to be good now, using :ref:

Aljames