### PR TITLE
Apply landing page patterns to developer/reference docs.

### DIFF
--- a/docs/developer/reference/css.rst
+++ b/docs/developer/reference/css.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: CSS and SCSS style guide for Launchpad development.
 
+.. _css-style-guide:
+
 ===============
 CSS style guide
 ===============

--- a/docs/developer/reference/email.rst
+++ b/docs/developer/reference/email.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Launchpad email processing reference. 
 
+.. _email-reference:
+
 Launchpad and email
 ===================
 

--- a/docs/developer/reference/index.rst
+++ b/docs/developer/reference/index.rst
@@ -14,13 +14,10 @@ Style guides give a clear guideline how certain aspects of Launchpad's code
 should be formatted, styled and handled, especially for the cases when there is
 no tooling available to enforce those rules.
 
-.. toctree::
-   :maxdepth: 1
-
-   python
-   tests
-   css
-   bug-tags
+- :ref:`Python style guide <python-style-guide>`
+- :ref:`Tests style guide <tests-style-guide>`
+- :ref:`CSS style guide <css-style-guide>`
+- :ref:`Tagging bugs about Launchpad <tagging-bugs-about-launchpad>`
 
 Services
 --------
@@ -32,54 +29,60 @@ hold of the log files, and where to find further information.
 Build-related
 ~~~~~~~~~~~~~
 
-.. toctree::
-   :maxdepth: 1
-
-   services/build-farm
-   services/signing
-   services/fetch-service
-   services/buildbot
+- :ref:`Build farm <build-farm-reference>`
+- :ref:`Signing service <signing-service>`
+- :ref:`Fetch service <fetch-service>`
+- :ref:`Buildbot <buildbot-reference>`
 
 Translation
 ~~~~~~~~~~~
 
-.. toctree::
-   :maxdepth: 1
-
-   services/automatic-translations-export.rst
+- :ref:`Automatic translations tarball exports <automatic-translations-export>`
 
 Ubuntu-related
 ~~~~~~~~~~~~~~
 
-.. toctree::
-   :maxdepth: 1
-
-   services/mirror-prober.rst
-   services/ubuntu-mirrors-index.rst
+- :ref:`Mirror prober <mirror-prober-reference>`
+- :ref:`Ubuntu mirrors index <ubuntu-mirrors-index>`
 
 Git-related
 ~~~~~~~~~~~~~~
 
+- :ref:`Git hosting <git-hosting-reference>`
+- :ref:`Code import <code-import-reference>`
+
+Archived
+~~~~~~~~
+These services are no longer available but you can still access the archived 
+information.
+
+- :ref:`Launchpad public mailing lists archives <mailing-lists-archives>`
+
+Email (outdated)
+----------------
+This information on the email services may contain outdated information and 
+will be updated in due course.
+
+- :ref:`Launchpad and email <email-reference>`
+   
 .. toctree::
-   :maxdepth: 1
+   :hidden:
 
-   services/git-hosting.rst
-   services/code-import.rst
-
-Others
-~~~~~~
-
-.. toctree::
-   :maxdepth: 1
-
-   services/mailing-lists-archives.rst
-
-Possibly out-of-date
---------------------
-
-We will update these items as soon as possible.
-
-.. toctree::
-   :maxdepth: 1
-
+   python
+   tests
+   css
+   bug-tags
+   services/build-farm
+   services/signing
+   services/fetch-service
+   services/buildbot
+   services/automatic-translations-export
+   services/mirror-prober
+   services/ubuntu-mirrors-index
+   services/git-hosting
+   services/code-import
+   services/mailing-lists-archives
    email
+
+   
+

--- a/docs/developer/reference/index.rst
+++ b/docs/developer/reference/index.rst
@@ -51,10 +51,10 @@ Git-related
 - :ref:`Git hosting <git-hosting-reference>`
 - :ref:`Code import <code-import-reference>`
 
-Archived
-~~~~~~~~
-These services are no longer available but you can still access the archived 
-information.
+Mailing Lists
+~~~~~~~~~~~~~
+Launchpad mailing lists are not available any more, but you can still 
+access the archived information.
 
 - :ref:`Launchpad public mailing lists archives <mailing-lists-archives>`
 

--- a/docs/developer/reference/index.rst
+++ b/docs/developer/reference/index.rst
@@ -58,10 +58,8 @@ information.
 
 - :ref:`Launchpad public mailing lists archives <mailing-lists-archives>`
 
-Email (outdated)
-----------------
-This information on the email services may contain outdated information and 
-will be updated in due course.
+Email
+-----
 
 - :ref:`Launchpad and email <email-reference>`
    

--- a/docs/developer/reference/index.rst
+++ b/docs/developer/reference/index.rst
@@ -34,6 +34,17 @@ Build-related
 - :ref:`Fetch service <fetch-service>`
 - :ref:`Buildbot <buildbot-reference>`
 
+Email
+~~~~~
+
+- :ref:`Launchpad and email <email-reference>`
+
+Git-related
+~~~~~~~~~~~~~~
+
+- :ref:`Git hosting <git-hosting-reference>`
+- :ref:`Code import <code-import-reference>`
+
 Translation
 ~~~~~~~~~~~
 
@@ -45,12 +56,6 @@ Ubuntu-related
 - :ref:`Mirror prober <mirror-prober-reference>`
 - :ref:`Ubuntu mirrors index <ubuntu-mirrors-index>`
 
-Git-related
-~~~~~~~~~~~~~~
-
-- :ref:`Git hosting <git-hosting-reference>`
-- :ref:`Code import <code-import-reference>`
-
 Mailing Lists
 ~~~~~~~~~~~~~
 Launchpad mailing lists are not available any more, but you can still 
@@ -58,10 +63,6 @@ access the archived information.
 
 - :ref:`Launchpad public mailing lists archives <mailing-lists-archives>`
 
-Email
------
-
-- :ref:`Launchpad and email <email-reference>`
    
 .. toctree::
    :hidden:

--- a/docs/developer/reference/services/automatic-translations-export.rst
+++ b/docs/developer/reference/services/automatic-translations-export.rst
@@ -2,6 +2,8 @@
    :description: The schedule of automatic translations tarball exports from 
       Launchpad.
 
+.. _automatic-translations-export:
+
 Automatic translations tarball exports
 ======================================
 

--- a/docs/developer/reference/services/build-farm.rst
+++ b/docs/developer/reference/services/build-farm.rst
@@ -2,7 +2,7 @@
    :description: Reference doc linking to resources related to the Launchpad 
       build farm including documentation, git repositories, and bug trackers.
 
-.. _build-farm:
+.. _build-farm-reference:
 
 Build farm
 ==========

--- a/docs/developer/reference/services/buildbot.rst
+++ b/docs/developer/reference/services/buildbot.rst
@@ -2,6 +2,8 @@
    :description: Reference doc for the Buildbot CI testing framework used by 
       Launchpad linking to documentation, log files, git repositories, etc.
 
+.. _buildbot-reference:
+
 Buildbot
 ========
 

--- a/docs/developer/reference/services/code-import.rst
+++ b/docs/developer/reference/services/code-import.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Reference doc for Launchpad's Git import system.
 
+.. _code-import-reference:
+
 Code import
 ===========
 

--- a/docs/developer/reference/services/fetch-service.rst
+++ b/docs/developer/reference/services/fetch-service.rst
@@ -15,7 +15,7 @@ proxy. When used, it keeps track of requests and dependencies for the build.
 Detailed description
 --------------------
 The fetch service is a proxy service used by Launchpad builders (see
-:ref:`Build Farm <build-farm>`) that keeps track of dependencies downloaded
+:ref:`Build Farm <build-farm-reference>`) that keeps track of dependencies downloaded
 during a build. This ensures developers have a trustworthy record of all the
 parts that make up the software being built.
 

--- a/docs/developer/reference/services/git-hosting.rst
+++ b/docs/developer/reference/services/git-hosting.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Reference document for Launchpad's Git hosting service.
 
+.. _git-hosting-reference:
+
 Git hosting
 ===============
 

--- a/docs/developer/reference/services/mailing-lists-archives.rst
+++ b/docs/developer/reference/services/mailing-lists-archives.rst
@@ -2,6 +2,8 @@
    :description: All about the archive of Launchpad's deprecated mailing list 
       service.
 
+.. _mailing-lists-archives:
+
 Launchpad public mailing lists archives
 =======================================
 

--- a/docs/developer/reference/services/mirror-prober.rst
+++ b/docs/developer/reference/services/mirror-prober.rst
@@ -2,6 +2,8 @@
    :description: Reference document for the the mirror prober script and how to
       access the log files.
 
+.. _mirror-prober-reference:
+
 Mirror prober
 =============
 

--- a/docs/developer/reference/services/signing.rst
+++ b/docs/developer/reference/services/signing.rst
@@ -2,6 +2,8 @@
    :description: Reference document for Launchpad's signing service with links 
       to documentation, deployment information, git repository, and bug tracker.
 
+.. _signing-service:
+
 Signing service
 ===============
 

--- a/docs/developer/reference/services/ubuntu-mirrors-index.rst
+++ b/docs/developer/reference/services/ubuntu-mirrors-index.rst
@@ -1,6 +1,8 @@
 .. meta::
    :description: Reference document for the Ubuntu mirrors index service.
 
+.. _ubuntu-mirrors-index:
+
 Ubuntu mirrors index
 ==================== 
 


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
