### PR TITLE
Update references to a long-dead product

### DIFF
--- a/docs/user/explanation/translating-with-launchpad/translate-your-software.rst
+++ b/docs/user/explanation/translating-with-launchpad/translate-your-software.rst
@@ -402,7 +402,7 @@ Below you will find a set of common practices for running a team
          already finished translations. For languages with few
          translators and translations already done team acceptance could
          be lower than in the case of a language with many translators,
-         translations made and the presence of GTP, OpenOffice , etc
+         translations made and the presence of GTP, LibreOffice, etc
          upstream translation projects.
       -  Before accepting a member you may ask him/her to provide some
          translation. If the translations are great you may accept the

--- a/docs/user/reference/bug-tracker-api/external-bug-statuses.rst
+++ b/docs/user/reference/bug-tracker-api/external-bug-statuses.rst
@@ -10,7 +10,7 @@ External bug statuses
 .. include:: /includes/important_not_revised_help.rst
 
 
-Bugs in free software projects are often tracked in more than one place. For example: a bug in Firefox may be tracked in Launchpad by Ubuntu's Firefox team and in Firefox's own Bugzilla instance.
+Bugs in free software projects are often tracked in more than one place. For example: a bug in Firefox may be tracked in Launchpad by the Ubuntu Mozilla Team and in Firefox's own Bugzilla instance.
 
 Translating the status of external bug watches
 ----------------------------------------------

--- a/docs/user/reference/bug-tracker-api/external-bug-statuses.rst
+++ b/docs/user/reference/bug-tracker-api/external-bug-statuses.rst
@@ -10,12 +10,12 @@ External bug statuses
 .. include:: /includes/important_not_revised_help.rst
 
 
-Bugs in free software projects are often tracked in more than one place. For example: a bug in OpenOffice.org may be tracked in Launchpad by Ubuntu's OpenOffice.org team and in OpenOffice.org's own Bugzilla instance.
+Bugs in free software projects are often tracked in more than one place. For example: a bug in Firefox may be tracked in Launchpad by Ubuntu's Firefox team and in Firefox's own Bugzilla instance.
 
 Translating the status of external bug watches
 ----------------------------------------------
 
-Launchpad can track the status of the bug in OpenOffice.org's external tracker and display its current status on the Ubuntu team's bug report.
+Launchpad can track the status of the bug in Firefox's external tracker and display its current status on the Ubuntu team's bug report.
 
 Bugzilla and Launchpad use different statuses to describe the stages of a bug's lifecycle. It could quickly become confusing to use two different sets of bug statuses on the same page. Instead, Launchpad translates the status of the external bug report.
 

--- a/docs/user/reference/translations/translators-group.rst
+++ b/docs/user/reference/translations/translators-group.rst
@@ -18,7 +18,7 @@ software.
 There is one Launchpad localization team appointed for each language.
 
 We encourage Ubuntu, Debian, Fedora, GNOME, KDE, Mozilla,
-OpenOffice.org and all other translators dedicated to a specific
+LibreOffice and all other translators dedicated to a specific
 project to join the localization team appointed for their language.
 
 We also encourage project maintainers to appoint the **Launchpad


### PR DESCRIPTION
It’s been the case since 2010 ;)

I hope it isn’t controversial.

-   [x] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
