### PR TITLE
Update release notes for April 2026

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,11 +9,10 @@ Release Notes
 
 April 2026
 ++++++++++
-
 13 April
 
-- Added build_path option to snap package recipes, allowing for having multiple
-snapcraft.yaml in the same repository.
+- Added the `build_path` option to snap package recipes, allowing for having multiple
+  `snapcraft.yaml` in the same repository.
 
 December 2025
 +++++++++++++

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -7,6 +7,14 @@
 Release Notes
 =============
 
+April 2026
+++++++++++
+
+13 April
+
+- Added build_path option to snap package recipes, allowing for having multiple
+snapcraft.yaml in the same repository.
+
 December 2025
 +++++++++++++
 


### PR DESCRIPTION
Added release notes for April 2026, including new build_path option.

-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
