### PR TITLE
Add release notes for removing blog posts from frontpage

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -13,6 +13,7 @@ April 2026
 
 - Added the `build_path` option to snap package recipes, allowing for having multiple
   `snapcraft.yaml` in the same repository.
+- Removed blog posts from frontpage (link to blog is still available in the footer)
 
 December 2025
 +++++++++++++


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
