### PR TITLE
Add release notes for March 2026

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -14,6 +14,23 @@ April 2026
 - Added the `build_path` option to snap package recipes, allowing for having multiple
   `snapcraft.yaml` in the same repository.
 
+
+March 2026
+++++++++++
+31 March
+
+- Fixed Ubuntu milestones timeout.
+
+20 March
+
+- Fixed snap, charm and source package listings and Merge Proposals active
+  reviews timeouts.
+
+12 March
+
+- Export `BinaryPackageBuild.distro_series` to the API.
+- Add admin-only `cancel_upload` API endpoint for builds.
+
 December 2025
 +++++++++++++
 


### PR DESCRIPTION
-   [x] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
