### PR TITLE
doc: Add explanation for "valid_until_config"

### DIFF
--- a/docs/developer/explanation/core-components-and-set-up/publisher/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/publisher/index.rst
@@ -11,3 +11,4 @@ Publisher
 
    ubuntu-package-publishing
    ubuntu-archive-publisher
+   valid-until

--- a/docs/developer/explanation/core-components-and-set-up/publisher/valid-until.rst
+++ b/docs/developer/explanation/core-components-and-set-up/publisher/valid-until.rst
@@ -56,5 +56,9 @@ for a distribution series using the Launchpad API::
     In [9]: stonking.valid_until_config
     Out[9]: {'Backports': {'refresh_threshold': 7, 'validity_period': 14}}
 
-This example sets a ``refresh_threshold`` of 7 days and a ``validity_period`` 
-of 14 days for the Release file.
+This configurations above is used during the publishing runs:
+
+-  ``refresh_threshold``: Refresh the Valid-Until tag, when it is within this 
+   many days from being expired. 
+-  ``validity_period``: Number of days the Release file will remain valid from 
+   the day of refreshing. 

--- a/docs/developer/explanation/core-components-and-set-up/publisher/valid-until.rst
+++ b/docs/developer/explanation/core-components-and-set-up/publisher/valid-until.rst
@@ -1,0 +1,60 @@
+.. meta::
+   :description: Overview of the valid_until_config on a distroseries
+
+.. _valid-until-config:
+
+Valid-Until configuration for distribution series
+==================================================
+
+Overview
+--------
+
+The ``valid_until_config`` feature adds support for configuring 
+``Valid-Until`` tags in APT repository Release files for Launchpad 
+distribution series. This allows fine-grained control over how long 
+repository metadata remains valid, improving security by ensuring clients 
+regularly refresh repository information.
+
+What is Valid-Until?
+---------------------
+
+The ``Valid-Until`` field in APT Release files specifies an expiration 
+timestamp for repository metadata. APT clients will refuse to use Release 
+files that have expired, forcing them to fetch fresh metadata. This security 
+feature helps prevent replay attacks and ensures clients have up-to-date 
+repository information.
+
+Permissions
+-----------
+
+The ``valid_until_config`` property can be:
+
+-  **Read** by anyone with access to view the distribution series
+-  **Modified** only by users with edit permissions on the distribution 
+   series (typically distribution owners and administrators)
+
+For API access, see the `DistroSeries API documentation 
+<https://api.launchpad.net/devel.html#distro_series>`_.
+
+Example usage
+-------------
+
+The following example demonstrates how to configure ``valid_until_config`` 
+for a distribution series using the Launchpad API::
+
+    In [5]: stonking = lp.load(
+    ...    "https://api.launchpad.net/devel/ubuntu/stonking")
+
+    In [6]: stonking.valid_until_config
+    Out[6]: {}
+
+    In [7]: stonking.valid_until_config = {
+    ...    'Backports': {'refresh_threshold': 7, 'validity_period': 14}}
+
+    In [8]: stonking.lp_save()
+
+    In [9]: stonking.valid_until_config
+    Out[9]: {'Backports': {'refresh_threshold': 7, 'validity_period': 14}}
+
+This example sets a ``refresh_threshold`` of 7 days and a ``validity_period`` 
+of 14 days for the Release file.

--- a/docs/developer/explanation/core-components-and-set-up/publisher/valid-until.rst
+++ b/docs/developer/explanation/core-components-and-set-up/publisher/valid-until.rst
@@ -60,5 +60,7 @@ This configurations above is used during the publishing runs:
 
 -  ``refresh_threshold``: Refresh the Valid-Until tag, when it is within this 
    many days from being expired. 
--  ``validity_period``: Number of days the Release file will remain valid from 
-   the day of refreshing. 
+-  ``validity_period``: The number of days before expiration at which the 
+   Valid-Until value is refreshed.
+
+


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
