### PR TITLE
Change unreliable old link with archive.org equivalent.

### DIFF
--- a/docs/developer/explanation/development-best-practices/assertions-in-launchpad.rst
+++ b/docs/developer/explanation/development-best-practices/assertions-in-launchpad.rst
@@ -57,7 +57,7 @@ we should be raising an error, instead::
 
 It is interesting to note what Tim Peters thinks of assertions.
 
-http://mail.python.org/pipermail/python-dev/2000-November/010670.html
+https://web.archive.org/web/20260216031622/http://mail.python.org/pipermail/python-dev/2000-November/010670.html
 
 Testing your asserts
 --------------------


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Replace old Python mailing list link with archive org equivalent. The current link has recently been returning a 429 client error.