### PR TITLE
Update builder-specs doc to show the correct/unchanged details.

### DIFF
--- a/docs/user/reference/packaging/builder-specs.rst
+++ b/docs/user/reference/packaging/builder-specs.rst
@@ -7,7 +7,8 @@
 Builder specs
 =============
 
-Launchpad's builders currently run with the following configuration for all architectures except for ppc64el:
+Launchpad's builders currently run with the following configuration for all
+architectures except for ppc64el and amd64:
 
 - CPUs: 8
 
@@ -17,7 +18,7 @@ Launchpad's builders currently run with the following configuration for all arch
 
 - SWAP: 8 GB
 
-For ppc64el we have the following spec in place:
+For ppc64el and amd64 we have the following spec in place:
 
 - CPUs: 4
 


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Correct the details of the builder specs. amd64 builders are yet to be upgraded to the specs currently shown in the builder specs doc.

Preview page: https://canonical-ubuntu-documentation-library--504.com.readthedocs.build/launchpad/user/reference/packaging/builder-specs/