### PR TITLE
Add release notes entries for the deployment on 13 May 2026

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -10,6 +10,15 @@ Release Notes
 May 2026
 ++++++++
 
+13 May
+
+- Provide an RSS feed for accepted uploads in an Ubuntu
+  series similar to the emails sent to the configured mailing list address on
+  lists.ubuntu.com.
+
+- Fixed the CD image mirror prober to check the Content-Type returned by the probed
+  URLs for the .iso images to better detect broken mirrors.
+
 12 May
 
 - Removed suppression of snap manifest generation for private snap builds. For 


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
