### PR TITLE
Feat: Update user/how-to landing page to capture underlying vision.

### DIFF
--- a/docs/user/how-to/account-management/index.rst
+++ b/docs/user/how-to/account-management/index.rst
@@ -8,7 +8,8 @@
 Manage your account
 ===================
 
-These guides help you create and manage your Launchpad account.
+A Launchpad account gives you access to the platform's full range of features,
+including code hosting, bug tracking, and package publishing.
 
 To get started with Launchpad, you need to create a user account. You can
 `sign up here <https://launchpad.net/+login>`_.

--- a/docs/user/how-to/index.rst
+++ b/docs/user/how-to/index.rst
@@ -42,8 +42,9 @@ Package Archives (PPAs), as well as snaps, rocks, charms, and OCI images.
 Manage bugs
 -----------
 The bug tracker lets you file, subscribe to, and manage bugs across your
-projects. It also integrates with external trackers - including Bugzilla, Trac,
-and Mantis - and can link bug reports directly to code branches.
+projects. It also integrates with external trackers including Bugzilla, Trac,
+GitLab, and Mantis, allows you to link bug reports directly to code branches,
+and more.
 
 - :ref:`Work with bugs <work-with-bugs>`
 
@@ -51,16 +52,17 @@ Use the API
 -----------
 Launchpad exposes most of its data and actions through a REST API.
 ``launchpadlib``, the official Python client library, lets you script Launchpad
-operations as Python objects without dealing with raw HTTP. You can also call
-the API directly from other languages or tools.
+operations as Python objects without dealing with raw HTTP. You can also use
+the API directly.
 
 - :ref:`Use the Launchpad web services API <launchpad-web-services-api>`
 - :ref:`Work with launchpadlib <work-with-launchpadlib>`
 
 Contribute to the community 
 ---------------------------
-Launchpad Answers lets you respond to support questions from other users. You
-can also take on an ongoing role as an answer contact for a specific project.
+As an answer contact, you will be called upon to help the community by
+responding to both new and frequently asked questions. You may also receive
+a lot of mail which you can filter based on your personal preferences.
 
 - :ref:`Help the community <help-the-community>`
 

--- a/docs/user/how-to/index.rst
+++ b/docs/user/how-to/index.rst
@@ -8,8 +8,8 @@ How-to guides
 =============
 
 Launchpad supports a wide range of workflows - from managing accounts and
-hosting code, to building packages and tracking bugs. The guides in this
-section provide step-by-step instructions for specific tasks.
+hosting code, to building packages and tracking bugs. This section provides
+step-by-step instructions for specific tasks.
 
 Manage your account and access
 ------------------------------
@@ -60,8 +60,7 @@ the API directly from other languages or tools.
 Contribute to the community 
 ---------------------------
 Launchpad Answers lets you respond to support questions from other users. You
-can also take on an ongoing role as an answer contact for a specific project or
-distribution, ensuring questions get timely responses.
+can also take on an ongoing role as an answer contact for a specific project.
 
 - :ref:`Help the community <help-the-community>`
 

--- a/docs/user/how-to/index.rst
+++ b/docs/user/how-to/index.rst
@@ -7,67 +7,61 @@
 How-to guides
 =============
 
-If you are already familiar with Launchpad, these how-to guides can provide 
-guidance on how to achieve specific goals when using the platform. You can
-adapt these to meet other needs, but you may need to refer to some explanation 
-and reference docs as well.
+Launchpad supports a wide range of workflows - from managing accounts and
+hosting code, to building packages and tracking bugs. The guides in this
+section provide step-by-step instructions for specific tasks.
 
-Account and access management
------------------------------
-You need a user account to access many Launchpad features. There are additional 
-options to customize your account, and you may also need to set up 
-authentication using SSH and GPG keys.
+Manage your account and access
+------------------------------
+You need a user account to access most Launchpad features. Once set up, you can
+authenticate with SSH and GPG keys and use your Launchpad credentials across
+other OpenID-compatible websites.
 
 -  :ref:`Create and manage your Launchpad account <account-management>`
 -  :ref:`Import your SSH key <import-your-ssh-keys>`
 -  :ref:`Import an OpenPGP key <import-an-openpgp-key>`
-
-Since Launchpad uses OpenID, once you set up your account, you can use the same 
-credentials to :ref:`log into other websites <log-into-websites-with-openid>`.
+-  :ref:`Log into other websites with OpenID <log-into-websites-with-openid>`
 
 Manage your projects and code
 -----------------------------
-Hosting your project code on Launchpad allows you to collaborate with others,
-build software packages from the code for distribution, translate the project 
-into other languages, and more.
+Launchpad hosts your project's code repositories and provides tools for code
+review, branching, merge proposals, and linking code to bugs and blueprints.
 
 - :ref:`Manage projects <howto-projects>`
 - :ref:`Work with code hosted on Launchpad <work-with-code-hosted-launchpad>`
 
-Software Packages
------------------
-Launchpad allows you to build software packages from source code without having
-to manage any build infrastructure. You can upload source packages to a 
-Personal Package Archive (PPA), where Launchpad builds them into installable 
-binary packages.
+Build and publish packages
+--------------------------
+Launchpad builds software packages from your source code without requiring you
+to manage build infrastructure. This includes Debian packages in Personal
+Package Archives (PPAs), as well as snaps, rocks, charms, and OCI images.
 
 - :ref:`Upload, build, and install software packages <packaging-how-to>`
 - :ref:`Create a source package recipe <create-a-source-package-recipe>`
 
 Manage bugs
 -----------
-There are many ways to work with bugs on Launchpad from simply filing bug 
-reports and subscribing to bugs, to using plugins to track bugs in external 
-trackers and linking bugs to branches.
+The bug tracker lets you file, subscribe to, and manage bugs across your
+projects. It also integrates with external trackers - including Bugzilla, Trac,
+and Mantis - and can link bug reports directly to code branches.
 
 - :ref:`Work with bugs <work-with-bugs>`
 
-API access
-----------
-The Launchpad API allows you to interact with Launchpad using scripts, 
-applications, and other websites. You can also use ``launchpadlib`` which allows
-you to treat the resources published by the API as Python objects. This makes 
-integration with other applications more straightforward.
+Use the API
+-----------
+Launchpad exposes most of its data and actions through a REST API.
+``launchpadlib``, the official Python client library, lets you script Launchpad
+operations as Python objects without dealing with raw HTTP. You can also call
+the API directly from other languages or tools.
 
 - :ref:`Use the Launchpad web services API <launchpad-web-services-api>`
 - :ref:`Work with launchpadlib <work-with-launchpadlib>`
 
 Contribute to the community 
 ---------------------------
-When you sign up to Launchpad you get to benefit from the contributions 
-of other community members. There are different ways that you can also give 
-back to the community, e.g., by becoming an answer contact for a project or 
-responding to questions others post on Launchpad Answers.
+Launchpad Answers lets you respond to support questions from other users. You
+can also take on an ongoing role as an answer contact for a specific project or
+distribution, ensuring questions get timely responses.
 
 - :ref:`Help the community <help-the-community>`
 

--- a/docs/user/how-to/packaging/index.rst
+++ b/docs/user/how-to/packaging/index.rst
@@ -8,6 +8,11 @@ Packaging
 =========
 .. include:: /includes/important_not_revised_help.rst
 
+Launchpad builds software packages from your source code using its own build
+infrastructure. You can publish Debian packages through a Personal Package
+Archive (PPA), or build snaps, rocks, charms, and OCI images for other
+distribution channels.
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/user/how-to/projects/index.rst
+++ b/docs/user/how-to/projects/index.rst
@@ -9,6 +9,10 @@ Projects
 
 .. include:: /includes/important_not_revised_help.rst
 
+Launchpad gives your project a central hub for tracking development activity.
+You can register a project, manage ownership and permissions, and coordinate
+translations into multiple languages.
+
 .. toctree::
     :hidden:
     :maxdepth: 1

--- a/docs/user/how-to/work-with-bugs/index.rst
+++ b/docs/user/how-to/work-with-bugs/index.rst
@@ -9,6 +9,10 @@ Work with bugs
 
 .. include:: /includes/important_not_revised_help.rst
 
+Launchpad's bug tracker lets you file and manage bugs across projects and
+distributions. You can subscribe to bugs, link them to code branches, manage
+them through email, and integrate with external trackers.
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/user/how-to/work-with-code-hosted-on-launchpad/index.rst
+++ b/docs/user/how-to/work-with-code-hosted-on-launchpad/index.rst
@@ -9,6 +9,10 @@ Work with code hosted on Launchpad
 
 .. include:: /includes/important_not_revised_help.rst
 
+Launchpad hosts Git repositories for your projects and provides tools for
+branching, code review, and merge proposals. You can also link commits and
+branches directly to bugs and blueprints.
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/user/how-to/work-with-code-hosted-on-launchpad/index.rst
+++ b/docs/user/how-to/work-with-code-hosted-on-launchpad/index.rst
@@ -10,8 +10,8 @@ Work with code hosted on Launchpad
 .. include:: /includes/important_not_revised_help.rst
 
 Launchpad hosts Git repositories for your projects and provides tools for
-branching, code review, and merge proposals. You can also link commits and
-branches directly to bugs and blueprints.
+branching, code review, and merge proposals. You can link merge proposals to
+bugs (including via commit messages) and associate your work with blueprints.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Landing page preview: https://canonical-ubuntu-documentation-library--525.com.readthedocs.build/launchpad/user/how-to/
