### PR TITLE
Update user/ref landing to capture the vision of the underlying docs

### DIFF
--- a/docs/user/reference/bug-tracker-api/index.rst
+++ b/docs/user/reference/bug-tracker-api/index.rst
@@ -7,6 +7,11 @@
 Bug tracker API
 ===============
 
+The bug tracker API provides programmatic access to Launchpad's bug tracking
+features. Review API-specific details including bug statuses, integration with
+external bug trackers, and the plugin API for extending bug tracker
+functionality.
+
 .. include:: /includes/important_not_revised_help.rst
 
 .. toctree::

--- a/docs/user/reference/bugs/index.rst
+++ b/docs/user/reference/bugs/index.rst
@@ -7,6 +7,11 @@
 Bugs
 ====
 
+Technical reference for Launchpad's bug tracking system, including bug
+attachments, subscriptions, expiry policies, heat calculations, and the email
+interface, plus multi-project bug management and bug integration with other
+Launchpad features.
+
 .. include:: /includes/important_not_revised_help.rst
 
 .. toctree::

--- a/docs/user/reference/index.rst
+++ b/docs/user/reference/index.rst
@@ -7,14 +7,14 @@
 Reference
 =========
 
-This reference section is useful for uncovering technical details as well as 
-available commands and feature options. You can also find definitions for 
-common terms used in this documentation in our :ref:`Glossary <glossary>`.
+Look up specific options, find exact requirements and constraints, or verify
+syntax and formatting. You can also find definitions for common terms used
+in this documentation in the :ref:`Glossary <glossary>`.
 
-Account options
----------------
-Look up consumer hosting options, troubleshooting options for your Launchpad 
-account, and fingerprints for SSH end points.
+Account setup and security
+--------------------------
+Configure your Launchpad account credentials and access methods, compare
+sharing policies for proprietary repositories, and look up SSH fingerprints.
 
 - :ref:`Consumer hosting options <consumer-hosting>`
 - :ref:`Troubleshooting your account <ref-troubleshooting>`
@@ -23,7 +23,7 @@ account, and fingerprints for SSH end points.
 Community and support
 ---------------------
 Frequently asked questions, platform and licensing policies, support best 
-practices, data handling policies, and more.
+practices, and data handling policies.
 
 - :ref:`Launchpad and community <launchpad-and-community>`
 - :ref:`Privacy and confidentiality <branch-information-types>`
@@ -42,32 +42,30 @@ code review roles, and Live Filesystems.
 
 Bugs
 ----
-Summary of available options when using the Launchpad bug tracker and the bug 
-tracker API, including a list of supported external bug trackers, bug roles, 
-and available bug statuses.
+Available options when using the Launchpad bug tracker and the bug tracker API,
+including supported external bug trackers, bug roles, and available bug
+statuses.
 
 - :ref:`Bugs references <bugs>`
 - :ref:`Bug tracker API <ref-bug-tracker-api>`
 
 API 
 ---
-Find out about compatibility between launchpadlib and different Ubuntu versions,
-and which applications currently use the API and how they use it.
-
+Check compatibility between launchpadlib and different Ubuntu versions, plus
+list of applications using it.
 - :ref:`API compatibility <launchpadlib-api-compatibility>`
 - :ref:`Applications using launchpadlib <table-of-applications-using-the-api>`
 
 Project groups and team membership
 ----------------------------------
-Look up requirements for setting up project groups, and team membership 
-policies.
+Requirements for setting up project groups, and team membership policies.
 
 - :ref:`Project groups in Launchpad <project-groups>`
 - :ref:`Team membership policies <ref-teams>`
 
 Syntax and style guides
 -----------------------
-Elements of the comments syntax on Launchpad including bug and branch linking, 
+Elements of the comment syntax on Launchpad including bug and branch linking, 
 and how whitespace is addressed.
 
 - :ref:`Launchpad comment parsing <launchpad-comment-parsing>`
@@ -76,24 +74,24 @@ and how whitespace is addressed.
    :hidden:
    :maxdepth: 1
 
+   Consumer hosting <consumer-hosting>
+   SSH fingerprints <ssh-fingerprints>
+   Privacy and confidentiality <privacy-and-confidentiality>
+   Troubleshooting <troubleshooting/index>
+   Support in your native language <native-language-support>
+   Project groups <project-groups>
+   Teams <teams/index>
+   Roles in code review <code-review-roles>
+   Packaging <packaging/index>
+   Live-file-systems <live-file-systems>
    Bugs <bugs/index>
    Bug tracker API <bug-tracker-api/index>
-   Commenting syntax <comment-syntax>
-   Consumer hosting <consumer-hosting>
-   Glossary <glossary>
-   Launchpad and community <launchpad-and-community/index>
    launchpadlib API compatibility <launchpadlib-api-compatibility>
-   Live-file-systems <live-file-systems>
-   Loggerhead <loggerhead>
-   Packaging <packaging/index>
-   Privacy and confidentiality <privacy-and-confidentiality>
-   Project groups <project-groups>
-   Roles in code review <code-review-roles>
-   SSH fingerprints <ssh-fingerprints>
-   Support in your native language <native-language-support>
    Table of applications using the API <api-uses>
-   Teams <teams/index>
-   Translations <translations/index>
-   Troubleshooting <troubleshooting/index>
+   Loggerhead <loggerhead>
+   Launchpad and community <launchpad-and-community/index>
    Question life cycle <question-life-cycle>
+   Translations <translations/index>
+   Commenting syntax <comment-syntax>
+   Glossary <glossary>
    User preferences <settings-and-preferences>

--- a/docs/user/reference/index.rst
+++ b/docs/user/reference/index.rst
@@ -22,10 +22,9 @@ sharing policies for proprietary repositories, and look up SSH fingerprints.
 
 Community and support
 ---------------------
-Download and display the Launchpad badge, templates for asking questions plus
-the question lifecycle, platform and licensing policies, control who knows
-about your branch, and navigate getting or providing support in your native
-language.
+Launchpad badges, templates for asking questions plus the question lifecycle,
+platform and licensing policies, branch privacy, and getting or providing
+support in your native language.
 
 - :ref:`Launchpad and community <launchpad-and-community>`
 - :ref:`Privacy and confidentiality <branch-information-types>`
@@ -45,8 +44,7 @@ code review roles, and Live Filesystems.
 Bugs
 ----
 Available options when using the Launchpad bug tracker and the bug tracker API,
-including supported external bug trackers, bug roles, and available bug
-statuses.
+including supported external bug trackers, bug roles, and bug statuses.
 
 - :ref:`Bugs references <bugs>`
 - :ref:`Bug tracker API <ref-bug-tracker-api>`
@@ -76,24 +74,24 @@ and how whitespace is addressed.
    :hidden:
    :maxdepth: 1
 
-   Consumer hosting <consumer-hosting>
-   SSH fingerprints <ssh-fingerprints>
-   Privacy and confidentiality <privacy-and-confidentiality>
-   Troubleshooting <troubleshooting/index>
-   Support in your native language <native-language-support>
-   Project groups <project-groups>
-   Teams <teams/index>
-   Roles in code review <code-review-roles>
-   Packaging <packaging/index>
-   Live-file-systems <live-file-systems>
    Bugs <bugs/index>
    Bug tracker API <bug-tracker-api/index>
-   launchpadlib API compatibility <launchpadlib-api-compatibility>
-   Table of applications using the API <api-uses>
-   Loggerhead <loggerhead>
-   Launchpad and community <launchpad-and-community/index>
-   Question life cycle <question-life-cycle>
-   Translations <translations/index>
    Commenting syntax <comment-syntax>
+   Consumer hosting <consumer-hosting>
    Glossary <glossary>
+   Launchpad and community <launchpad-and-community/index>
+   launchpadlib API compatibility <launchpadlib-api-compatibility>
+   Live-file-systems <live-file-systems>
+   Loggerhead <loggerhead>
+   Packaging <packaging/index>
+   Privacy and confidentiality <privacy-and-confidentiality>
+   Project groups <project-groups>
+   Question life cycle <question-life-cycle>
+   Roles in code review <code-review-roles>
+   SSH fingerprints <ssh-fingerprints>
+   Support in your native language <native-language-support>
+   Table of applications using the API <api-uses>
+   Teams <teams/index>
+   Translations <translations/index>
+   Troubleshooting <troubleshooting/index>
    User preferences <settings-and-preferences>

--- a/docs/user/reference/index.rst
+++ b/docs/user/reference/index.rst
@@ -22,8 +22,10 @@ sharing policies for proprietary repositories, and look up SSH fingerprints.
 
 Community and support
 ---------------------
-Frequently asked questions, platform and licensing policies, support best 
-practices, and data handling policies.
+Download and display the Launchpad badge, templates for asking questions plus
+the question lifecycle, platform and licensing policies, control who knows
+about your branch, and navigate getting or providing support in your native
+language.
 
 - :ref:`Launchpad and community <launchpad-and-community>`
 - :ref:`Privacy and confidentiality <branch-information-types>`

--- a/docs/user/reference/launchpad-and-community/index.rst
+++ b/docs/user/reference/launchpad-and-community/index.rst
@@ -7,6 +7,9 @@
 Launchpad and community
 =======================
 
+Badges and recognition systems for Launchpad users, legal and licensing
+requirements, and support resources.
+
 .. include:: /includes/important_not_revised_help.rst
 
 .. toctree::

--- a/docs/user/reference/packaging/index.rst
+++ b/docs/user/reference/packaging/index.rst
@@ -7,6 +7,10 @@
 Packaging
 =========
 
+Technical specifications for Launchpad's package build infrastructure, including
+Personal Package Archives (PPAs), build specifications, builder availability
+and scoring, and source build management. 
+
 .. include:: /includes/important_not_revised_help.rst
 
 .. toctree::

--- a/docs/user/reference/teams/index.rst
+++ b/docs/user/reference/teams/index.rst
@@ -6,6 +6,9 @@
 Teams
 =========
 
+Teams customization options on Launchpad - setting team policies, managing
+membership, and team roles and responsibilities.
+
 .. include:: /includes/important_not_revised_help.rst
 
 .. toctree::

--- a/docs/user/reference/translations/index.rst
+++ b/docs/user/reference/translations/index.rst
@@ -7,6 +7,10 @@
 Translations
 ============
 
+Translation workflows, language-specific guidelines, permissions and policies,
+licensing requirements, and best practices, including options for managing
+translations, sharing across projects, and supporting multiple languages.
+
 .. include:: /includes/important_not_revised_help.rst
 
 .. toctree::

--- a/docs/user/reference/troubleshooting/index.rst
+++ b/docs/user/reference/troubleshooting/index.rst
@@ -6,6 +6,8 @@
 Troubleshooting
 ===============
 
+Solutions for common Launchpad issues and errors.
+
 .. toctree::
     :maxdepth: 1
 


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Landing page preview: https://canonical-ubuntu-documentation-library--527.com.readthedocs.build/launchpad/user/reference/