### PR TITLE
Feat: Add an introductory paragraph to Launchpad's user/tutorial section

### DIFF
--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -6,8 +6,9 @@
 Tutorials
 =========
 
-Take a comprehensive, guided introduction to using Launchpad starting with
-launchpadlib, a Python library that allows you to interact with Launchpad's API.
+Explore Launchpad through a series of comprehensive and guided tutorials,
+starting with launchpadlib, a Python library that allows you to interact with
+Launchpad's API.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -6,7 +6,8 @@
 Tutorials
 =========
 
-These tutorials will help you get started working with Launchpad.
+Take a comprehensive, guided introduction to using Launchpad starting with
+launchpadlib, a Python library that allows you to interact with Launchpad's API.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Landing page preview: https://canonical-ubuntu-documentation-library--529.com.readthedocs.build/launchpad/user/tutorial/