### PR TITLE
Update dev exp landing

### DIFF
--- a/docs/developer/explanation/core-components-and-set-up/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/index.rst
@@ -5,9 +5,8 @@
 Core components and setting up Launchpad
 ========================================
 
-Launchpad is a large, Zope Toolkit-based application made up of many
-interdependent subsystems including code hosting, the publisher, mailing system,
-and pip. 
+Launchpad is a Zope-based application made up of many subsystems including code 
+hosting, a bug tracker, build farm, and package publisher. 
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/core-components-and-set-up/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/index.rst
@@ -5,6 +5,10 @@
 Core components and setting up Launchpad
 ========================================
 
+Launchpad is a large, Zope Toolkit-based application made up of many
+interdependent subsystems including code hosting, the publisher, mailing system,
+and pip. 
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/developer/explanation/core-components-and-set-up/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/index.rst
@@ -6,7 +6,7 @@ Core components and setting up Launchpad
 ========================================
 
 Launchpad is a Zope-based application made up of many subsystems including code 
-hosting, a bug tracker, build farm, and package publisher. 
+hosting, a bug tracker, a build farm, and a package publisher. 
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/core-components-and-set-up/parts-of-launchpad/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/parts-of-launchpad/index.rst
@@ -6,8 +6,8 @@
 Parts of Launchpad
 ===================
 
-Launchpad is not a single application but a collection of distinct functional
-units that share a codebase.
+Launchpad is a single platform composed of multiple functional subsystems that
+share a common codebase.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/core-components-and-set-up/parts-of-launchpad/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/parts-of-launchpad/index.rst
@@ -6,8 +6,11 @@
 Parts of Launchpad
 ===================
 
+Launchpad is not a single application but a collection of distinct functional
+areas that share a common codebase and component architecture.
+
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    code
    engineering-overview-translations

--- a/docs/developer/explanation/core-components-and-set-up/parts-of-launchpad/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/parts-of-launchpad/index.rst
@@ -7,7 +7,7 @@ Parts of Launchpad
 ===================
 
 Launchpad is not a single application but a collection of distinct functional
-areas that share a common codebase and component architecture.
+units that share a codebase.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/core-components-and-set-up/publisher/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/publisher/index.rst
@@ -6,6 +6,9 @@
 Publisher
 ===================
 
+The Launchpad publisher is the subsystem responsible for taking accepted
+packages and making them available to ``apt`` clients.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/developer/explanation/core-components-and-set-up/publisher/index.rst
+++ b/docs/developer/explanation/core-components-and-set-up/publisher/index.rst
@@ -7,7 +7,7 @@ Publisher
 ===================
 
 The Launchpad publisher is the subsystem responsible for taking accepted
-packages and making them available to ``apt`` clients.
+packages and making them available in the Ubuntu archive or a PPA.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/database/index.rst
+++ b/docs/developer/explanation/database/index.rst
@@ -7,9 +7,9 @@
 Database
 =========
 
-Launchpad is deeply integrated with PostgreSQL, making deliberate use of
-stored procedures, triggers, functional indexes, and full-text search —
-features that go well beyond what a generic ORM layer would expose.
+Launchpad uses a PostgreSQL database, making use of stored procedures, triggers,
+functional indexes, and other PostgreSQL-specific features. It uses `Storm <https://storm-orm.readthedocs.io/en/latest/>`_
+as its object-relational mapper (ORM).
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/database/index.rst
+++ b/docs/developer/explanation/database/index.rst
@@ -7,7 +7,7 @@
 Database
 =========
 
-Launchpad uses a PostgreSQL database, making use of stored procedures, triggers,
+Launchpad uses PostgreSQL, making use of stored procedures, triggers,
 functional indexes, and other PostgreSQL-specific features. It uses `Storm <https://storm-orm.readthedocs.io/en/latest/>`_
 as its object-relational mapper (ORM).
 

--- a/docs/developer/explanation/database/index.rst
+++ b/docs/developer/explanation/database/index.rst
@@ -7,6 +7,10 @@
 Database
 =========
 
+Launchpad is deeply integrated with PostgreSQL, making deliberate use of
+stored procedures, triggers, functional indexes, and full-text search —
+features that go well beyond what a generic ORM layer would expose.
+
 .. toctree::
    :maxdepth: 1
    

--- a/docs/developer/explanation/developing-for-launchpad/index.rst
+++ b/docs/developer/explanation/developing-for-launchpad/index.rst
@@ -7,6 +7,9 @@
 Developing the Launchpad project
 ================================
 
+Contributing to Launchpad means navigating a workflow shaped by the project's
+scale and its continuous-deployment model.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/developer/explanation/development-best-practices/index.rst
+++ b/docs/developer/explanation/development-best-practices/index.rst
@@ -5,6 +5,9 @@
 Best practices for development
 ==============================
 
+Good Launchpad code is fast, available, and safe for others to modify. This is
+achieved by sticking to established best practices for Launchpad development.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/developer/explanation/development-best-practices/index.rst
+++ b/docs/developer/explanation/development-best-practices/index.rst
@@ -5,8 +5,9 @@
 Best practices for development
 ==============================
 
-Good Launchpad code is fast, available, and safe for others to modify. This is
-achieved by sticking to established best practices for Launchpad development.
+Good Launchpad code is fast, available, and modifiable with limited risk to
+other subsystems. This is achieved by sticking to established best practices for
+Launchpad development.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/ideas-behind-launchpad/index.rst
+++ b/docs/developer/explanation/ideas-behind-launchpad/index.rst
@@ -6,8 +6,8 @@
 The ideas behind Launchpad
 ==========================
 
-Before writing a line of Launchpad code it helps to understand the foundational
-ideas behind the platform, what it aims to achieve and how.
+Before you start contributing to Launchpad, it helps to understand the
+foundational ideas behind the platform, what it aims to achieve and how.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/ideas-behind-launchpad/index.rst
+++ b/docs/developer/explanation/ideas-behind-launchpad/index.rst
@@ -6,6 +6,9 @@
 The ideas behind Launchpad
 ==========================
 
+Before writing a line of Launchpad code it helps to understand the foundational
+ideas behind the platform, what it aims to achieve and how.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/developer/explanation/index.rst
+++ b/docs/developer/explanation/index.rst
@@ -44,9 +44,8 @@ helps you navigate the codebase, and design and test your changes.
 Database
 --------
 
-Launchpad stores its data in PostgreSQL and depends on PostgreSQL-specific
-features. Its schema is patched on a live system and managed with Storm, the
-ORM Launchpad uses.
+Launchpad uses PostgreSQL and depends on PostgreSQL-specific features. Its
+schema is patched on a live system and managed by Storm, the ORM Launchpad uses.
 
 - :ref:`Database performance <database-performance>`
 - :ref:`Live database patching <live-database-patching>`

--- a/docs/developer/explanation/index.rst
+++ b/docs/developer/explanation/index.rst
@@ -5,17 +5,17 @@
 Explanation
 ===========
 
-Launchpad is a large platform built over many years on the Zope Toolkit,
-PostgreSQL, and a substantial body of Python and JavaScript. These pages
-explain the ideas behind the project, the components that make up the platform,
-and the practices its developers follow.
+Launchpad is a large platform built over many years. These pages explain the
+ideas behind the project, its components, and the best practices its developers
+follow.
 
 The ideas behind Launchpad
 --------------------------
 
-Launchpad connects the networks of people who make software with the network of
-dependencies between their projects. Understanding why Launchpad exists, who it
-serves, and the values that guide it provides the context for everything else.
+Launchpad connects the people who make software with users and other developers,
+and offers the resources they need to make their software available.
+Understanding why Launchpad exists, whom it serves, and the values that guide
+it provides the context for everything else.
 
 - :ref:`What is Launchpad? <what-is-launchpad>`
 - :ref:`About Launchpad security <about-launchpad-security>`
@@ -26,8 +26,8 @@ serves, and the values that guide it provides the context for everything else.
 Core components and setup
 -------------------------
 
-Launchpad is made up of many interdependent components. Knowing how these
-pieces fit together helps you navigate the codebase and run a working instance.
+Launchpad is made up of many components. Knowing how these pieces fit together
+helps you navigate the codebase, and design and test your changes.
 
 - :ref:`Parts of Launchpad <parts-of-launchpad>`
 - :ref:`Publisher <explanation-publisher>`
@@ -44,10 +44,9 @@ pieces fit together helps you navigate the codebase and run a working instance.
 Database
 --------
 
-Launchpad stores its data in PostgreSQL and depends heavily on
-PostgreSQL-specific features such as stored procedures, triggers, and language
-extensions. Its schema is patched on a live system and managed with Storm, the
-object-relational mapper Launchpad uses.
+Launchpad stores its data in PostgreSQL and depends on PostgreSQL-specific
+features. Its schema is patched on a live system and managed with Storm, the
+ORM Launchpad uses.
 
 - :ref:`Database performance <database-performance>`
 - :ref:`Live database patching <live-database-patching>`
@@ -58,10 +57,10 @@ object-relational mapper Launchpad uses.
 Developing for the Launchpad project
 ------------------------------------
 
-Contributing to Launchpad means working across several long-lived branches,
-guarding new behaviour behind feature flags, and shepherding each change
-through review and into production. These topics cover the conventions and
-processes that shape day-to-day development.
+Contributing to Launchpad means working across several branches, guarding new
+behaviour behind feature flags, and guiding each change through review and
+into production. This day-to-day development is expected to follow specific
+processes and conventions.
 
 - :ref:`About Launchpad branches <about-launchpad-branches>`
 - :ref:`Datetime usage guide <datetime-usage-guide>`
@@ -75,7 +74,8 @@ processes that shape day-to-day development.
 Best practices for development
 ------------------------------
 
-Launchpad aims to be fast, always available, and safe to change. These
+Launchpad aims to be fast and always available. It should also be safe to
+change parts of it with a low risk of breaking other parts of the system. These
 principles inform how its code is structured, how performance and permissions
 are handled, and how its templates and tests are written.
 
@@ -93,9 +93,8 @@ are handled, and how its templates and tests are written.
 JavaScript
 ----------
 
-Launchpad's interactive front end is written in JavaScript built on the YUI
-library, with its own build system and both unit and integration test
-frameworks.
+Launchpad's front end is written in JavaScript built on the YUI library, with
+its own build system and both unit and integration test frameworks.
 
 - :ref:`JavaScript build system <javascript-build-system>`
 - :ref:`Integration testing in JavaScript <integration-testing-in-javascript>`
@@ -106,8 +105,7 @@ Static assets
 -------------
 
 Launchpad's visual style comes from CSS and images that are compiled and
-optimized as part of the build, including CSS sprites that combine many small
-images into one.
+optimized as part of the build using CSS sprites.
 
 - :ref:`CSS <launchpad-css>`
 - :ref:`CSS sprites <use-css-sprites>`

--- a/docs/developer/explanation/index.rst
+++ b/docs/developer/explanation/index.rst
@@ -1,20 +1,21 @@
 .. meta::
-   :description: Explanation documentation covering Launchpad ideas, setup, 
+   :description: Documentation covering Launchpad ideas, setup, 
       framework, parts, best practices, and deployment processes.
 
 Explanation
 ===========
 
-Launchpad is a large project developed over many years. The explanation 
-documentation take you through the ideas behind its development, the different 
-parts that make up the platform, how typical Launchpad developers approach 
-their roles, and more.
+Launchpad is a large platform built over many years on the Zope Toolkit,
+PostgreSQL, and a substantial body of Python and JavaScript. These pages
+explain the ideas behind the project, the components that make up the platform,
+and the practices its developers follow.
 
 The ideas behind Launchpad
----------------------------
+--------------------------
 
-Explore these pages for an overview of the concepts and motivations behind the 
-Launchpad project. 
+Launchpad connects the networks of people who make software with the network of
+dependencies between their projects. Understanding why Launchpad exists, who it
+serves, and the values that guide it provides the context for everything else.
 
 - :ref:`What is Launchpad? <what-is-launchpad>`
 - :ref:`About Launchpad security <about-launchpad-security>`
@@ -22,13 +23,11 @@ Launchpad project.
 - :ref:`Launchpad values <launchpad-values>`
 
 
-Understand the Launchpad set up and components
-----------------------------------------------
+Core components and setup
+-------------------------
 
-To make meaningful contributions to the project, you'll need to understand how 
-Launchpad is installed and configured, how to navigate the codebase and test 
-your changes. You should also understand the different components that make up
-the application.
+Launchpad is made up of many interdependent components. Knowing how these
+pieces fit together helps you navigate the codebase and run a working instance.
 
 - :ref:`Parts of Launchpad <parts-of-launchpad>`
 - :ref:`Publisher <explanation-publisher>`
@@ -45,8 +44,10 @@ the application.
 Database
 --------
 
-This section gives an overview of how Launchpad interacts with the PostgreSQL 
-database.
+Launchpad stores its data in PostgreSQL and depends heavily on
+PostgreSQL-specific features such as stored procedures, triggers, and language
+extensions. Its schema is patched on a live system and managed with Storm, the
+object-relational mapper Launchpad uses.
 
 - :ref:`Database performance <database-performance>`
 - :ref:`Live database patching <live-database-patching>`
@@ -57,8 +58,10 @@ database.
 Developing for the Launchpad project
 ------------------------------------
 
-These pages help explain important aspects of the developer experience when 
-you start contributing to Launchpad.
+Contributing to Launchpad means working across several long-lived branches,
+guarding new behaviour behind feature flags, and shepherding each change
+through review and into production. These topics cover the conventions and
+processes that shape day-to-day development.
 
 - :ref:`About Launchpad branches <about-launchpad-branches>`
 - :ref:`Datetime usage guide <datetime-usage-guide>`
@@ -70,10 +73,11 @@ you start contributing to Launchpad.
 - :ref:`XXX policy <xxx-policy>`
 
 Best practices for development
--------------------------------
+------------------------------
 
-By using these principled approaches to development, you can improve Launchpad 
-in a way that is sustainable and maintainable.
+Launchpad aims to be fast, always available, and safe to change. These
+principles inform how its code is structured, how performance and permissions
+are handled, and how its templates and tests are written.
 
 - :ref:`Architectural guide <architectural-guide>`
 - :ref:`Assertions in Launchpad <assertions-in-launchpad>`
@@ -89,8 +93,9 @@ in a way that is sustainable and maintainable.
 JavaScript
 ----------
 
-These pages explain how to develop, test, and build using the YUI Test 
-framework.
+Launchpad's interactive front end is written in JavaScript built on the YUI
+library, with its own build system and both unit and integration test
+frameworks.
 
 - :ref:`JavaScript build system <javascript-build-system>`
 - :ref:`Integration testing in JavaScript <integration-testing-in-javascript>`
@@ -100,8 +105,9 @@ framework.
 Static assets
 -------------
 
-Launchpad's visual style is controlled by CSS and images that you set up and 
-build.
+Launchpad's visual style comes from CSS and images that are compiled and
+optimized as part of the build, including CSS sprites that combine many small
+images into one.
 
 - :ref:`CSS <launchpad-css>`
 - :ref:`CSS sprites <use-css-sprites>`

--- a/docs/developer/explanation/javascript/index.rst
+++ b/docs/developer/explanation/javascript/index.rst
@@ -5,9 +5,9 @@
 JavaScript
 ===========
 
-Launchpad's interactive front end is built on the YUI 3 library and ships
-its JavaScript through a custom build system that bundles and minifies
-modules into a single ``launchpad.js`` file.
+Launchpad's front end is built using the YUI 3 library and ships its JavaScript
+through a custom build system that bundles and minifies modules into a single
+``launchpad.js`` file.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/javascript/index.rst
+++ b/docs/developer/explanation/javascript/index.rst
@@ -5,6 +5,10 @@
 JavaScript
 ===========
 
+Launchpad's interactive front end is built on the YUI 3 library and ships
+its JavaScript through a custom build system that bundles and minifies
+modules into a single ``launchpad.js`` file.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/developer/explanation/javascript/index.rst
+++ b/docs/developer/explanation/javascript/index.rst
@@ -6,8 +6,7 @@ JavaScript
 ===========
 
 Launchpad's front end is built using the YUI 3 library and ships its JavaScript
-through a custom build system that bundles and minifies modules into a single
-``launchpad.js`` file.
+through a custom build system.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/static-assets/index.rst
+++ b/docs/developer/explanation/static-assets/index.rst
@@ -7,8 +7,8 @@
 Static assets
 ==============
 
-Launchpad's visual style uses a set of carefully organised static assets that
-include CSS, images, and favicons, and css-sprites.
+Launchpad's visual style uses CSS, CSS sprites, and static assets
+(images and favicons).
 
 .. toctree::
    :maxdepth: 1

--- a/docs/developer/explanation/static-assets/index.rst
+++ b/docs/developer/explanation/static-assets/index.rst
@@ -7,6 +7,9 @@
 Static assets
 ==============
 
+Launchpad's visual style uses a set of carefully organised static assets that
+include CSS, images, and favicons, and css-sprites.
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Update the developer explanation landing page to better capture the vision of the underlying docs.
Preview: https://canonical-ubuntu-documentation-library--537.com.readthedocs.build/launchpad/developer/explanation/