### PR TITLE
Feat: Update the dev/tutorial landing page to better capture the vision of the underlying docs

### DIFF
--- a/docs/developer/tutorials/index.rst
+++ b/docs/developer/tutorials/index.rst
@@ -7,8 +7,9 @@
 Tutorials
 =========
 
-If you are considering becoming a Launchpad developer, these tutorials guide 
-you through different tasks to familiarize you with the experience. 
+Working on Launchpad means navigating a large, feature-rich codebase and a
+well-defined development workflow. Build some familiarity with both by working
+through these tutorials.
 
 - :ref:`Creating a new page in Launchpad <tutorial-creating-page-in-launchpad>`
 - :ref:`Building charms in Launchpad <tutorial-building-charms-in-launchpad>`


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

Preview: https://canonical-ubuntu-documentation-library--539.com.readthedocs.build/launchpad/developer/tutorials/