### PR TITLE
chore: Add _dev directory to gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _dev/vale.ini
 
 # Build outputs
 _build
+_dev
 
 # Node.js
 package*.json


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
`_dev` is a build directory and changes to it should not be committed. 