### PR TITLE
Add page Trunk/Glue mentioned in About Launchpad branches

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,7 +245,6 @@ linkcheck_ignore = [
     r"https://buildbot\.net.*", #ignore, expired SSL certificate
     r"https://docs\.buildbot\.net/.*", #ignore, expired SSL certificate
     "https://realpython.com/vim-and-python-a-match-made-in-heaven/",  # 403 Error
-    "Trunk/Glue",  #  needs update
     "/Background",
     "/Concepts",  #  needs update
     "JavascriptUnitTesting/MockIo",  #needs update

--- a/docs/developer/explanation/developing-for-launchpad/branches.rst
+++ b/docs/developer/explanation/developing-for-launchpad/branches.rst
@@ -39,7 +39,7 @@ In summary: **db-stable** is the post-test-run counterpart of
 it is only cleared into foo-stable if the buildbot test runner succeeds.
 
 If you want to know how all of this works behind the scenes, read
-`Trunk/Glue <Trunk/Glue>`__ (after reading the rest of this page).
+:ref:`journey-change-production` (after reading the rest of this page).
 
 Look at the pretty pictures
 ---------------------------

--- a/docs/developer/reference/services/buildbot.rst
+++ b/docs/developer/reference/services/buildbot.rst
@@ -33,7 +33,12 @@ setup.
    proposals and then merge them back to the private “production” branch
    before deployment. In the ``master.cfg`` file, we have defined all
    the necessary configurations (schedulers, workers, job steps) for
-   buildbot. 
+   buildbot. The scheduler used for the two trunk builders is an
+   ``AggregatingScheduler``, which watches a development branch
+   (``master`` or ``db-devel``) for changes. When it sees a change, it
+   checks whether the last build for that branch succeeded or failed. If
+   the last build failed, it only starts a new build when the commit
+   message contains ``[testfix]``.
 
    1. The buildmaster has a custom ``buildbot-poll.py`` cron script
       which is responsible for merging the commits within the main Launchpad repository in the
@@ -156,3 +161,8 @@ of your build and review the summary to identify the cause of the failure.
 If you suspect the build is failing due to flakiness of the test
 infrastructure and not your changes, you can `restart the build
 <http://lpbuildbot.canonical.com/force>`__.
+
+This "force build" page is a custom addition to buildbot's web UI, because
+buildbot's built-in "Force Build" button does not work for our setup. Builds
+forced this way carry a distinctive "reason" attribute that the
+``buildbot-poll.py`` script recognises via the JSON API.


### PR DESCRIPTION
-   [x] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----

This attempts to fix one of the broken links reported in https://github.com/canonical/open-documentation-academy/issues/78.
Specifically, it fixes the link Trunk/Glue present here:

https://github.com/canonical/launchpad-manual/blob/f32de2faa4703047c56b568f1d92c837423135aa/docs/developer/explanation/developing-for-launchpad/branches.rst?plain=1#L42

The link was broken as the page was missing. Checking this comment https://github.com/canonical/open-documentation-academy/issues/78#issuecomment-2182743392 by @nielsenjared, I found the original URL that unfortunately is unavailable nowadays. So I picked the most updated version I could find of that page on Web Archive (2024-10-17 https://web.archive.org/web/20241017062058/https://dev.launchpad.net/Trunk/Glue) and adapted it to the ReStructuredText format.