### PR TITLE
build: disable llms.txt for local builds

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,11 +6,11 @@
 # from the environment for the first two.
 
 DEV_DIR          ?= _dev
-SPHINX_OPTS      ?= -c . -d $(DEV_DIR)/.doctrees -j auto
+SPHINX_OPTS      ?= -c . -d $(DEV_DIR)/.doctrees -j auto -D llms_txt_enabled=0
 SPHINX_BUILD     ?= $(DOCS_VENVDIR)/bin/sphinx-build
 SPHINX_HOST      ?= 127.0.0.1
 SPHINX_PORT      ?= 8000
-SPHINX_AUTOBUILD_OPTS ?= -D llms_txt_enabled=0
+SPHINX_AUTOBUILD_OPTS ?= 
 DOCS_VENVDIR     ?= .venv
 DOCS_VENV        ?= $(DOCS_VENVDIR)/bin/activate
 DOCS_SOURCEDIR   ?= .


### PR DESCRIPTION
The `llms.txt` generation is significantly impacting build times. Disable it by default for local builds.

This doesn't affect RTD builds, because those don't use the Makefile.


---

-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.