### PR TITLE
Refine developer reference landing page

### DIFF
--- a/docs/developer/reference/index.rst
+++ b/docs/developer/reference/index.rst
@@ -18,12 +18,6 @@ Build-related services descriptions and resources.
 - :ref:`Fetch service <fetch-service>`
 - :ref:`Buildbot <buildbot-reference>`
 
-Email processing testing
-------------------------
-Email processing configuration options and testing.
-
-- :ref:`Launchpad and email <email-reference>`
-
 Code imports and hosting
 ------------------------
 Code hosting and code import resources.
@@ -37,9 +31,15 @@ Schedule of automatic translations tarball exports from Launchpad.
 
 - :ref:`Automatic translations tarball exports <automatic-translations-export>`
 
+Interactive testing of Email processing
+---------------------------------------
+Email processing configuration options and testing.
+
+- :ref:`Launchpad and email <email-reference>`
+
 Ubuntu-related services
 -----------------------
-What are the Ubuntu mirrors index service and the mirror prober?
+Scanning for Ubuntu mirrors and checking their health. 
 
 - :ref:`Mirror prober <mirror-prober-reference>`
 - :ref:`Ubuntu mirrors index <ubuntu-mirrors-index>`

--- a/docs/developer/reference/index.rst
+++ b/docs/developer/reference/index.rst
@@ -4,9 +4,53 @@
 Reference
 =========
 
-Launchpad contributors are expected to follow certain coding standards. You'll
-also need technical reference material for services that make up the Launchpad
-platform when making contributions.
+Launchpad is composed of a monolith plus different services with distinct
+functions such as handling builds, code hosting, signing, translations,
+mirroring, and more. As a contributor working on any part of Launchpad, you
+are expected to follow certain conventions and standards in your work.
+
+Build-related services
+----------------------
+Build-related services descriptions and resources.
+
+- :ref:`Build farm <build-farm-reference>`
+- :ref:`Signing service <signing-service>`
+- :ref:`Fetch service <fetch-service>`
+- :ref:`Buildbot <buildbot-reference>`
+
+Email processing testing
+------------------------
+Email processing configuration options and testing.
+
+- :ref:`Launchpad and email <email-reference>`
+
+Code imports and hosting
+------------------------
+Code hosting and code import resources.
+
+- :ref:`Git hosting <git-hosting-reference>`
+- :ref:`Code import <code-import-reference>`
+
+Translation
+-----------
+Schedule of automatic translations tarball exports from Launchpad.
+
+- :ref:`Automatic translations tarball exports <automatic-translations-export>`
+
+Ubuntu-related services
+-----------------------
+What are the Ubuntu mirrors index service and the mirror prober?
+
+- :ref:`Mirror prober <mirror-prober-reference>`
+- :ref:`Ubuntu mirrors index <ubuntu-mirrors-index>`
+
+Mailing lists (archived)
+------------------------
+
+Launchpad mailing lists are no longer active, but the archives remain
+accessible.
+
+- :ref:`Launchpad public mailing lists archives <mailing-lists-archives>`
 
 Code conventions
 ----------------
@@ -19,51 +63,7 @@ tagging. These standards are enforced during code review.
 - :ref:`CSS style guide <css-style-guide>`
 - :ref:`Tagging bugs about Launchpad <tagging-bugs-about-launchpad>`
 
-Services
---------
 
-Launchpad is composed of many services that handle builds, code hosting,
-signing, translations, mirroring, and more.
-
-Build-related
-~~~~~~~~~~~~~
-
-- :ref:`Build farm <build-farm-reference>`
-- :ref:`Signing service <signing-service>`
-- :ref:`Fetch service <fetch-service>`
-- :ref:`Buildbot <buildbot-reference>`
-
-Email
-~~~~~
-
-- :ref:`Launchpad and email <email-reference>`
-
-Git-related
-~~~~~~~~~~~
-
-- :ref:`Git hosting <git-hosting-reference>`
-- :ref:`Code import <code-import-reference>`
-
-Translation
-~~~~~~~~~~~
-
-- :ref:`Automatic translations tarball exports <automatic-translations-export>`
-
-Ubuntu-related
-~~~~~~~~~~~~~~
-
-- :ref:`Mirror prober <mirror-prober-reference>`
-- :ref:`Ubuntu mirrors index <ubuntu-mirrors-index>`
-
-Mailing lists (archived)
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-Launchpad mailing lists are no longer active, but the archives remain
-accessible.
-
-- :ref:`Launchpad public mailing lists archives <mailing-lists-archives>`
-
-   
 .. toctree::
    :hidden:
 


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
Preview: https://canonical-launchpad-documentation--574.com.readthedocs.build/developer/reference/