### PR TITLE
chore: Pin Vale to version 13.0.0 to prevent false positives from spellchecker

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -31,4 +31,4 @@ sphinx-llm~=0.4
 
 # Vale dependencies
 rst2html
-vale~=3.13
+vale==3.13.0.0


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
The recent upgrades to Vale are causing the spellchecker to scan code and other parts of the doc it shouldn't. This is causing the spellchecker to find many false positives. This PR pins Vale to version 13.0.0 which doesn't have this issue.