### PR TITLE
Update release notes to include new getPublishedSources filters

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -13,8 +13,12 @@ August 2026
 28 August
 
 - Allowed pin priority setting for PPA dependencies. For more information, see
-   `Launchpad Manual create a Personal Package Archive page
-   <https://ubuntu.com/docs/launchpad/user/how-to/packaging/create-ppa/>`_.
+  `Launchpad Manual create a Personal Package Archive page
+  <https://ubuntu.com/docs/launchpad/user/how-to/packaging/create-ppa/>`_.
+- Added ``maintained_by``, ``changed_by``, ``signed_by``, ``packageset`` and ``team``
+  filters to ``Archive.getPublishedSources()``.
+- Added new ``order_by`` keys to ``Archive.getPublishedSources()``. It now also
+  allows to order by multiple keys.
 
 July 2026
 +++++++++


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
