### PR TITLE
chore: Add release note on fix for bug causing package picker to crash when search for packages in distributions.

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -19,6 +19,9 @@ August 2026
   filters to ``Archive.getPublishedSources()``.
 - Added new ``order_by`` keys to ``Archive.getPublishedSources()``. It now also
   allows to order by multiple keys.
+- Fixed bug that caused package picker to crash when searching for distribution
+  packages to target for bugs reported on projects.
+  See `bug report <https://code.launchpad.net/bugs/2161954>`_
 
 July 2026
 +++++++++


### PR DESCRIPTION
-   [ ] I ran `make linkcheck-discrete` locally to confirm new or edited links 
        will pass the linkcheck CI.

-----
